### PR TITLE
#48 Hub Route 구현

### DIFF
--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/RouteCalculationResult.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/RouteCalculationResult.java
@@ -1,0 +1,19 @@
+package com.devsquad10.hub.application.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RouteCalculationResult {
+	private Double distance;
+	private Integer duration;
+
+	// 경유 허브 리스트
+	private List<UUID> waypoints;
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/enums/HubRouteSortOption.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/enums/HubRouteSortOption.java
@@ -1,0 +1,13 @@
+package com.devsquad10.hub.application.dto.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum HubRouteSortOption {
+	CREATED_AT,
+	UPDATED_AT,
+	DISTANCE,
+	DURATION
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteCreateRequestDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteCreateRequestDto.java
@@ -1,0 +1,23 @@
+package com.devsquad10.hub.application.dto.req;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HubRouteCreateRequestDto {
+	@NotNull
+	private UUID departureHubId;
+
+	@NotNull
+	private UUID destinationHubId;
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteSearchRequestDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteSearchRequestDto.java
@@ -14,12 +14,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class HubRouteSearchRequestDto {
 	private UUID id;
 	private UUID departureHubId;

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteSearchRequestDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteSearchRequestDto.java
@@ -1,0 +1,64 @@
+package com.devsquad10.hub.application.dto.req;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.data.domain.Sort;
+
+import com.devsquad10.hub.application.dto.enums.HubRouteSortOption;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HubRouteSearchRequestDto {
+	private UUID id;
+	private UUID departureHubId;
+	private UUID destinationHubId;
+	private String departureHubName;
+	private String destinationHubName;
+
+	@PositiveOrZero
+	private Double minDistance;
+
+	@PositiveOrZero
+	private Double maxDistance;
+
+	@PositiveOrZero
+	private Integer minDuration;
+
+	@PositiveOrZero
+	private Integer maxDuration;
+
+	@Builder.Default
+	private Integer size = 10;
+
+	@Builder.Default
+	private Integer page = 0;
+
+	// TODO: Sort Option 관련 예외 처리
+	@Builder.Default
+	private HubRouteSortOption sortOption = HubRouteSortOption.CREATED_AT;
+
+	@Builder.Default
+	private Sort.Direction sortOrder = Sort.Direction.DESC;
+
+	public int getPage() {
+		return (page != null && page > 0) ? page - 1 : 0;
+	}
+
+	public int getSize() {
+		return Optional.ofNullable(size)
+			.filter(s -> Set.of(10, 30, 50).contains(s))
+			.orElse(10);
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteUpdateRequestDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/req/HubRouteUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.devsquad10.hub.application.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HubRouteUpdateRequestDto {
+	@NotNull
+	private Double distance;
+
+	@NotNull
+	private Integer duration;
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteCreateResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteCreateResponseDto.java
@@ -1,0 +1,46 @@
+package com.devsquad10.hub.application.dto.res;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.devsquad10.hub.domain.model.HubRoute;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HubRouteCreateResponseDto {
+	private UUID id;
+	private UUID departureHubId;
+	private String departureHubName;
+	private UUID destinationHubId;
+	private String destinationHubName;
+	private Double distance;
+	private Integer duration;
+	private LocalDateTime createdAt;
+	private UUID createdBy;
+	private List<UUID> waypoints;
+
+	public static HubRouteCreateResponseDto toResponseDto(HubRoute hubRoute, List<UUID> waypoints) {
+		return HubRouteCreateResponseDto.builder()
+			.id(hubRoute.getId())
+			.departureHubId(hubRoute.getDepartureHub().getId())
+			.departureHubName(hubRoute.getDepartureHub().getName())
+			.destinationHubId(hubRoute.getDestinationHub().getId())
+			.destinationHubName(hubRoute.getDestinationHub().getName())
+			.distance(hubRoute.getDistance())
+			.duration(hubRoute.getDuration())
+			.createdAt(hubRoute.getCreatedAt())
+			.createdBy(hubRoute.getCreatedBy())
+			.waypoints(waypoints)
+			.build();
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteGetOneResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteGetOneResponseDto.java
@@ -1,0 +1,46 @@
+package com.devsquad10.hub.application.dto.res;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.devsquad10.hub.domain.model.HubRoute;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class HubRouteGetOneResponseDto {
+	private UUID id;
+	private UUID departureHubId;
+	private String departureHubName;
+	private UUID destinationHubId;
+	private String destinationHubName;
+	private Double distance;
+	private Integer duration;
+	private LocalDateTime createdAt;
+	private UUID createdBy;
+	private LocalDateTime updatedAt;
+	private UUID updatedBy;
+
+	// TODO: 경유지 추후 구현
+	// private List<UUID> waypoints;
+
+	public static HubRouteGetOneResponseDto toResponseDto(HubRoute hubRoute) {
+		return HubRouteGetOneResponseDto.builder()
+			.id(hubRoute.getId())
+			.departureHubId(hubRoute.getDepartureHub().getId())
+			.departureHubName(hubRoute.getDepartureHub().getName())
+			.destinationHubId(hubRoute.getDestinationHub().getId())
+			.destinationHubName(hubRoute.getDestinationHub().getName())
+			.distance(hubRoute.getDistance())
+			.duration(hubRoute.getDuration())
+			.createdAt(hubRoute.getCreatedAt())
+			.createdBy(hubRoute.getCreatedBy())
+			.updatedAt(hubRoute.getUpdatedAt())
+			.updatedBy(hubRoute.getUpdatedBy())
+			.build();
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteUpdateResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteUpdateResponseDto.java
@@ -1,0 +1,42 @@
+package com.devsquad10.hub.application.dto.res;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.devsquad10.hub.domain.model.HubRoute;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class HubRouteUpdateResponseDto {
+	private UUID id;
+	private UUID departureHubId;
+	private String departureHubName;
+	private UUID destinationHubId;
+	private String destinationHubName;
+	private Double distance;
+	private Integer duration;
+	private LocalDateTime updatedAt;
+	private UUID updatedBy;
+	private List<UUID> waypoints;  // 경유지 정보
+
+	public static HubRouteUpdateResponseDto toResponseDto(HubRoute hubRoute, List<UUID> waypoints) {
+		return HubRouteUpdateResponseDto.builder()
+			.id(hubRoute.getId())
+			.departureHubId(hubRoute.getDepartureHub().getId())
+			.departureHubName(hubRoute.getDepartureHub().getName())
+			.destinationHubId(hubRoute.getDestinationHub().getId())
+			.destinationHubName(hubRoute.getDestinationHub().getName())
+			.distance(hubRoute.getDistance())
+			.duration(hubRoute.getDuration())
+			.updatedAt(hubRoute.getUpdatedAt())
+			.updatedBy(hubRoute.getUpdatedBy())
+			.waypoints(waypoints)
+			.build();
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubResponseDto.java
@@ -6,20 +6,30 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 
 import com.devsquad10.hub.application.dto.enums.HubSortOption;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @Builder
+@AllArgsConstructor
 public class PagedHubResponseDto implements Serializable {
 	private List<PagedHubItemResponseDto> hubs;
 	private int totalPages;
 	private long totalElements;
 	private int pageSize;
 	private int currentPage;
+
+	@JsonProperty("first")
 	private boolean isFirst;
+
+	@JsonProperty("last")
 	private boolean isLast;
+
 	private boolean hasNext;
 	private boolean hasPrevious;
 	private HubSortOption sortOption;

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubRouteItemResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubRouteItemResponseDto.java
@@ -1,0 +1,41 @@
+package com.devsquad10.hub.application.dto.res;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.devsquad10.hub.domain.model.HubRoute;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagedHubRouteItemResponseDto {
+	private UUID id;
+	private UUID departureHubId;
+	private String departureHubName;
+	private UUID destinationHubId;
+	private String destinationHubName;
+	private Double distance;
+	private Integer duration;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	public static PagedHubRouteItemResponseDto toResponseDto(HubRoute hubRoute) {
+		return PagedHubRouteItemResponseDto.builder()
+			.id(hubRoute.getId())
+			.departureHubId(hubRoute.getDepartureHub().getId())
+			.departureHubName(hubRoute.getDepartureHub().getName())
+			.destinationHubId(hubRoute.getDestinationHub().getId())
+			.destinationHubName(hubRoute.getDestinationHub().getName())
+			.distance(hubRoute.getDistance())
+			.duration(hubRoute.getDuration())
+			.createdAt(hubRoute.getCreatedAt())
+			.updatedAt(hubRoute.getUpdatedAt())
+			.build();
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubRouteResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubRouteResponseDto.java
@@ -5,20 +5,30 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 
 import com.devsquad10.hub.application.dto.enums.HubRouteSortOption;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PagedHubRouteResponseDto {
 	private List<PagedHubRouteItemResponseDto> hubRoutes;
 	private int totalPages;
 	private long totalElements;
 	private int pageSize;
 	private int currentPage;
+
+	@JsonProperty("first")
 	private boolean isFirst;
+
+	@JsonProperty("last")
 	private boolean isLast;
+
 	private boolean hasNext;
 	private boolean hasPrevious;
 	private HubRouteSortOption sortOption;

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubRouteResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/PagedHubRouteResponseDto.java
@@ -1,0 +1,43 @@
+package com.devsquad10.hub.application.dto.res;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.devsquad10.hub.application.dto.enums.HubRouteSortOption;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PagedHubRouteResponseDto {
+	private List<PagedHubRouteItemResponseDto> hubRoutes;
+	private int totalPages;
+	private long totalElements;
+	private int pageSize;
+	private int currentPage;
+	private boolean isFirst;
+	private boolean isLast;
+	private boolean hasNext;
+	private boolean hasPrevious;
+	private HubRouteSortOption sortOption;
+
+	public static PagedHubRouteResponseDto toResponseDto(
+		Page<PagedHubRouteItemResponseDto> page,
+		HubRouteSortOption sortOption
+	) {
+		return PagedHubRouteResponseDto.builder()
+			.hubRoutes(page.getContent())
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.pageSize(page.getSize())
+			.currentPage(page.getNumber() + 1)
+			.isFirst(page.isFirst())
+			.isLast(page.isLast())
+			.hasNext(page.hasNext())
+			.hasPrevious(page.hasPrevious())
+			.sortOption(sortOption)
+			.build();
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/exception/HubRouteNotFoundException.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/exception/HubRouteNotFoundException.java
@@ -1,0 +1,7 @@
+package com.devsquad10.hub.application.exception;
+
+public class HubRouteNotFoundException extends RuntimeException {
+	public HubRouteNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteCalculateService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteCalculateService.java
@@ -1,0 +1,8 @@
+package com.devsquad10.hub.application.service;
+
+import com.devsquad10.hub.application.dto.RouteCalculationResult;
+import com.devsquad10.hub.domain.model.Hub;
+
+public interface HubRouteCalculateService {
+	RouteCalculationResult calculateRoute(Hub departureHub, Hub destinationHub);
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -10,7 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.devsquad10.hub.application.dto.RouteCalculationResult;
 import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
 import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
+import com.devsquad10.hub.application.dto.res.HubRouteGetOneResponseDto;
 import com.devsquad10.hub.application.exception.HubNotFoundException;
+import com.devsquad10.hub.application.exception.HubRouteNotFoundException;
 import com.devsquad10.hub.domain.model.Hub;
 import com.devsquad10.hub.domain.model.HubRoute;
 import com.devsquad10.hub.domain.repository.HubRepository;
@@ -57,5 +59,13 @@ public class HubRouteService {
 
 		// return HubRouteCreateResponseDto.toResponseDto(savedRoute, calculationResult.getWaypoints());
 		return HubRouteCreateResponseDto.toResponseDto(savedRoute, dummyList);
+	}
+
+	@Transactional(readOnly = true)
+	public HubRouteGetOneResponseDto getOneHubRoute(UUID id) {
+		HubRoute hubRoute = hubRouteRepository.findById(id)
+			.orElseThrow(() -> new HubRouteNotFoundException("허브 경로를 찾을 수 없습니다."));
+
+		return HubRouteGetOneResponseDto.toResponseDto(hubRoute);
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -97,4 +97,13 @@ public class HubRouteService {
 		// return HubRouteUpdateResponseDto.toResponseDto(updatedRoute, calculationResult.getWaypoints());
 		return HubRouteUpdateResponseDto.toResponseDto(updatedRoute, dummyList);
 	}
+
+	public void deleteHubRoute(UUID id) {
+		HubRoute hubRoute = hubRouteRepository.findById(id)
+			.orElseThrow(() -> new HubRouteNotFoundException("허브 경로를 찾을 수 없습니다."));
+
+		// TODO: 사용자 정보 구현 시 수정
+		hubRoute.delete(UUID.randomUUID());
+		hubRouteRepository.save(hubRoute);
+	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -9,8 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.devsquad10.hub.application.dto.RouteCalculationResult;
 import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
+import com.devsquad10.hub.application.dto.req.HubRouteUpdateRequestDto;
 import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
 import com.devsquad10.hub.application.dto.res.HubRouteGetOneResponseDto;
+import com.devsquad10.hub.application.dto.res.HubRouteUpdateResponseDto;
 import com.devsquad10.hub.application.exception.HubNotFoundException;
 import com.devsquad10.hub.application.exception.HubRouteNotFoundException;
 import com.devsquad10.hub.domain.model.Hub;
@@ -67,5 +69,32 @@ public class HubRouteService {
 			.orElseThrow(() -> new HubRouteNotFoundException("허브 경로를 찾을 수 없습니다."));
 
 		return HubRouteGetOneResponseDto.toResponseDto(hubRoute);
+	}
+
+	public HubRouteUpdateResponseDto updateHubRoute(UUID id, HubRouteUpdateRequestDto request) {
+		HubRoute hubRoute = hubRouteRepository.findById(id)
+			.orElseThrow(() -> new HubRouteNotFoundException("허브 경로를 찾을 수 없습니다."));
+
+		RouteCalculationResult calculationResult =
+			hubRouteCalculateService.calculateRoute(hubRoute.getDepartureHub(), hubRoute.getDestinationHub());
+
+		hubRoute.update(
+			// TODO: 임시 값 설정
+			// calculationResult.getDistance(),
+			// calculationResult.getDuration()
+			(Math.random() * 10000),
+			((int)(Math.random() * 1000000))
+		);
+
+		// TODO: 임시 값 설정
+		List<UUID> dummyList = new ArrayList<>();
+		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111101"));
+		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111102"));
+		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111103"));
+
+		HubRoute updatedRoute = hubRouteRepository.save(hubRoute);
+
+		// return HubRouteUpdateResponseDto.toResponseDto(updatedRoute, calculationResult.getWaypoints());
+		return HubRouteUpdateResponseDto.toResponseDto(updatedRoute, dummyList);
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -1,0 +1,61 @@
+package com.devsquad10.hub.application.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devsquad10.hub.application.dto.RouteCalculationResult;
+import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
+import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
+import com.devsquad10.hub.application.exception.HubNotFoundException;
+import com.devsquad10.hub.domain.model.Hub;
+import com.devsquad10.hub.domain.model.HubRoute;
+import com.devsquad10.hub.domain.repository.HubRepository;
+import com.devsquad10.hub.domain.repository.HubRouteRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class HubRouteService {
+
+	private final HubRepository hubRepository;
+	private final HubRouteRepository hubRouteRepository;
+	private final HubRouteCalculateService hubRouteCalculateService;
+
+	public HubRouteCreateResponseDto createHubRoute(HubRouteCreateRequestDto request) {
+		Hub departureHub = hubRepository.findById(request.getDepartureHubId())
+			.orElseThrow(() -> new HubNotFoundException("출발 허브를 찾을 수 없습니다. ID: " + request.getDepartureHubId()));
+
+		Hub destinationHub = hubRepository.findById(request.getDestinationHubId())
+			.orElseThrow(() -> new HubNotFoundException("도착 허브를 찾을 수 없습니다. ID: " + request.getDestinationHubId()));
+
+		RouteCalculationResult calculationResult =
+			hubRouteCalculateService.calculateRoute(departureHub, destinationHub);
+
+		HubRoute hubRoute = HubRoute.builder()
+			.departureHub(departureHub)
+			.destinationHub(destinationHub)
+			// TODO: 임시 값 설정
+			// .distance(calculationResult.getDistance())
+			// .duration(calculationResult.getDuration())
+			.distance(Math.random() * 10000)
+			.duration((int)(Math.random() * 1000000))
+			.build();
+
+		HubRoute savedRoute = hubRouteRepository.save(hubRoute);
+
+		// TODO: 임시 값 설정
+		List<UUID> dummyList = new ArrayList<>();
+		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111101"));
+		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111102"));
+		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111103"));
+
+		// return HubRouteCreateResponseDto.toResponseDto(savedRoute, calculationResult.getWaypoints());
+		return HubRouteCreateResponseDto.toResponseDto(savedRoute, dummyList);
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -4,15 +4,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devsquad10.hub.application.dto.RouteCalculationResult;
 import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
+import com.devsquad10.hub.application.dto.req.HubRouteSearchRequestDto;
 import com.devsquad10.hub.application.dto.req.HubRouteUpdateRequestDto;
 import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
 import com.devsquad10.hub.application.dto.res.HubRouteGetOneResponseDto;
 import com.devsquad10.hub.application.dto.res.HubRouteUpdateResponseDto;
+import com.devsquad10.hub.application.dto.res.PagedHubRouteItemResponseDto;
+import com.devsquad10.hub.application.dto.res.PagedHubRouteResponseDto;
 import com.devsquad10.hub.application.exception.HubNotFoundException;
 import com.devsquad10.hub.application.exception.HubRouteNotFoundException;
 import com.devsquad10.hub.domain.model.Hub;
@@ -105,5 +109,13 @@ public class HubRouteService {
 		// TODO: 사용자 정보 구현 시 수정
 		hubRoute.delete(UUID.randomUUID());
 		hubRouteRepository.save(hubRoute);
+	}
+
+	public PagedHubRouteResponseDto getHub(HubRouteSearchRequestDto request) {
+		Page<HubRoute> hubRoutePage = hubRouteRepository.findAll(request);
+
+		Page<PagedHubRouteItemResponseDto> dtoPage = hubRoutePage.map(PagedHubRouteItemResponseDto::toResponseDto);
+
+		return PagedHubRouteResponseDto.toResponseDto(dtoPage, request.getSortOption());
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubToHubRelayCalculateService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubToHubRelayCalculateService.java
@@ -1,0 +1,11 @@
+package com.devsquad10.hub.application.service;
+
+import com.devsquad10.hub.application.dto.RouteCalculationResult;
+import com.devsquad10.hub.domain.model.Hub;
+
+public class HubToHubRelayCalculateService implements HubRouteCalculateService {
+	@Override
+	public RouteCalculationResult calculateRoute(Hub departureHub, Hub destinationHub) {
+		return null;
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateService.java
@@ -1,0 +1,14 @@
+package com.devsquad10.hub.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.devsquad10.hub.application.dto.RouteCalculationResult;
+import com.devsquad10.hub.domain.model.Hub;
+
+@Service
+public class P2PRouteCalculateService implements HubRouteCalculateService {
+	@Override
+	public RouteCalculationResult calculateRoute(Hub departureHub, Hub destinationHub) {
+		return null;
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/model/HubRoute.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/model/HubRoute.java
@@ -1,0 +1,102 @@
+package com.devsquad10.hub.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "p_hub_route")
+@SQLRestriction("deleted_at IS NULL")
+// TODO: Audit Fields 분리
+@EntityListeners(AuditingEntityListener.class)
+public class HubRoute {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	private Double distance;
+
+	private Integer duration;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "departure_hub_id", nullable = false)
+	private Hub departureHub;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "destination_hub_id", nullable = false)
+	private Hub destinationHub;
+
+	// TODO: Audit Fields 분리
+	@Column(name = "created_at", nullable = false, updatable = false)
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime createdAt;
+
+	@Column(name = "created_by", nullable = false, updatable = false)
+	private UUID createdBy;
+
+	@Column(name = "updated_at")
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "updated_by")
+	private UUID updatedBy;
+
+	@Column(name = "deleted_at")
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime deletedAt;
+
+	@Column(name = "deleted_by")
+	private UUID deletedBy;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = LocalDateTime.now();
+
+		// TODO: created_by
+		this.createdBy = UUID.randomUUID();
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+
+		// TODO: updated_by
+	}
+
+	public void update(Double distance, Integer duration) {
+		this.distance = distance;
+		this.duration = duration;
+	}
+
+	public void delete(UUID deletedBy) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = deletedBy;
+	}
+}
+

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepository.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepository.java
@@ -1,0 +1,7 @@
+package com.devsquad10.hub.domain.repository;
+
+import com.devsquad10.hub.domain.model.HubRoute;
+
+public interface HubRouteRepository {
+	HubRoute save(HubRoute hubRoute);
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepository.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepository.java
@@ -1,7 +1,12 @@
 package com.devsquad10.hub.domain.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import com.devsquad10.hub.domain.model.HubRoute;
 
 public interface HubRouteRepository {
 	HubRoute save(HubRoute hubRoute);
+
+	Optional<HubRoute> findById(UUID id);
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.devsquad10.hub.domain.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.devsquad10.hub.domain.model.HubRoute;
+import com.devsquad10.hub.infrastructure.repository.JpaHubRouteRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class HubRouteRepositoryImpl implements HubRouteRepository {
+
+	private final JpaHubRouteRepository jpaHubRouteRepository;
+
+	@Override
+	public HubRoute save(HubRoute hubRoute) {
+		return jpaHubRouteRepository.save(hubRoute);
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
@@ -3,8 +3,10 @@ package com.devsquad10.hub.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
+import com.devsquad10.hub.application.dto.req.HubRouteSearchRequestDto;
 import com.devsquad10.hub.domain.model.HubRoute;
 import com.devsquad10.hub.infrastructure.repository.JpaHubRouteRepository;
 
@@ -24,5 +26,10 @@ public class HubRouteRepositoryImpl implements HubRouteRepository {
 	@Override
 	public Optional<HubRoute> findById(UUID id) {
 		return jpaHubRouteRepository.findById(id);
+	}
+
+	@Override
+	public Page<HubRoute> findAll(HubRouteSearchRequestDto request) {
+		return jpaHubRouteRepository.findAll(request);
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
@@ -1,5 +1,8 @@
 package com.devsquad10.hub.domain.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.stereotype.Repository;
 
 import com.devsquad10.hub.domain.model.HubRoute;
@@ -16,5 +19,10 @@ public class HubRouteRepositoryImpl implements HubRouteRepository {
 	@Override
 	public HubRoute save(HubRoute hubRoute) {
 		return jpaHubRouteRepository.save(hubRoute);
+	}
+
+	@Override
+	public Optional<HubRoute> findById(UUID id) {
+		return jpaHubRouteRepository.findById(id);
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/config/RedisConfig.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.devsquad10.hub.infrastructure.config;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -9,11 +11,15 @@ import org.springframework.data.redis.cache.CacheKeyPrefix;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.devsquad10.hub.application.dto.res.HubGetOneResponseDto;
+import com.devsquad10.hub.application.dto.res.HubRouteGetOneResponseDto;
+import com.devsquad10.hub.application.dto.res.PagedHubResponseDto;
+import com.devsquad10.hub.application.dto.res.PagedHubRouteResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -24,20 +30,28 @@ public class RedisConfig {
 
 	public static final String HUB_CACHE = "hubCache";
 	public static final String HUB_SEARCH_CACHE = "hubSearchCache";
+	public static final String HUB_ROUTE_CACHE = "hubRouteCache";
+	public static final String HUB_ROUTE_SEARCH_CACHE = "hubRouteSearchCache";
 
 	private static final Duration DEFAULT_TTL = Duration.ofSeconds(120);
-	private static final Duration HUB_TTL = Duration.ofHours(1);
+	private static final Duration HUB_TTL = Duration.ofSeconds(300);
 	private static final Duration HUB_SEARCH_TTL = Duration.ofHours(1);
+	private static final Duration HUB_ROUTE_TTL = Duration.ofSeconds(300);
+	private static final Duration HUB_ROUTE_SEARCH_TTL = Duration.ofHours(1);
+
+	@Bean
+	public ObjectMapper redisObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return objectMapper;
+	}
 
 	@Bean
 	public RedisCacheManager cacheManager(
 		RedisConnectionFactory redisConnectionFactory
 	) {
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new JavaTimeModule());
-		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+		ObjectMapper objectMapper = redisObjectMapper();
 
 		RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
 			.entryTtl(DEFAULT_TTL)
@@ -45,27 +59,46 @@ public class RedisConfig {
 			.serializeKeysWith(RedisSerializationContext.SerializationPair
 				.fromSerializer(new StringRedisSerializer()))
 			.serializeValuesWith(RedisSerializationContext.SerializationPair
-				.fromSerializer(jsonSerializer));
+				.fromSerializer(RedisSerializer.java()));
 
-		RedisCacheConfiguration hubCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(HUB_TTL)
+		RedisCacheConfiguration customCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
 			.disableCachingNullValues()
 			.computePrefixWith(CacheKeyPrefix.simple())
-			.serializeValuesWith(RedisSerializationContext.SerializationPair
-				.fromSerializer(RedisSerializer.java()));
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
 
-		RedisCacheConfiguration hubSearchCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(HUB_SEARCH_TTL)
-			.disableCachingNullValues()
-			.serializeKeysWith(RedisSerializationContext.SerializationPair
-				.fromSerializer(new StringRedisSerializer()))
-			.serializeValuesWith(RedisSerializationContext.SerializationPair
-				.fromSerializer(RedisSerializer.java()));
+		Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+		cacheConfigurations.put(HUB_CACHE, customCacheConfiguration.entryTtl(HUB_TTL)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(
+					customSerializer(objectMapper, HubGetOneResponseDto.class)
+				)));
+
+		cacheConfigurations.put(HUB_SEARCH_CACHE, customCacheConfiguration.entryTtl(HUB_SEARCH_TTL)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(
+					customSerializer(objectMapper, PagedHubResponseDto.class)
+				)));
+
+		cacheConfigurations.put(HUB_ROUTE_CACHE, customCacheConfiguration.entryTtl(HUB_ROUTE_TTL)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(
+					customSerializer(objectMapper, HubRouteGetOneResponseDto.class)
+				)));
+
+		cacheConfigurations.put(HUB_ROUTE_SEARCH_CACHE, customCacheConfiguration.entryTtl(HUB_ROUTE_SEARCH_TTL)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(
+					customSerializer(objectMapper, PagedHubRouteResponseDto.class)
+				)));
 
 		return RedisCacheManager.builder(redisConnectionFactory)
 			.cacheDefaults(cacheConfiguration)
-			.withCacheConfiguration(HUB_CACHE, hubCacheConfig)
-			.withCacheConfiguration(HUB_SEARCH_CACHE, hubSearchCacheConfig)
+			.withInitialCacheConfigurations(cacheConfigurations)
 			.build();
+	}
+
+	private <T> Jackson2JsonRedisSerializer<T> customSerializer(ObjectMapper objectMapper, Class<T> type) {
+		return new Jackson2JsonRedisSerializer<>(objectMapper, type);
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/HubRouteRepositoryCustom.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/HubRouteRepositoryCustom.java
@@ -1,17 +1,10 @@
-package com.devsquad10.hub.domain.repository;
-
-import java.util.Optional;
-import java.util.UUID;
+package com.devsquad10.hub.infrastructure.repository;
 
 import org.springframework.data.domain.Page;
 
 import com.devsquad10.hub.application.dto.req.HubRouteSearchRequestDto;
 import com.devsquad10.hub.domain.model.HubRoute;
 
-public interface HubRouteRepository {
-	HubRoute save(HubRoute hubRoute);
-
-	Optional<HubRoute> findById(UUID id);
-
+public interface HubRouteRepositoryCustom {
 	Page<HubRoute> findAll(HubRouteSearchRequestDto request);
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/HubRouteRepositoryCustomImpl.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/HubRouteRepositoryCustomImpl.java
@@ -1,0 +1,102 @@
+package com.devsquad10.hub.infrastructure.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
+
+import com.devsquad10.hub.application.dto.enums.HubRouteSortOption;
+import com.devsquad10.hub.application.dto.req.HubRouteSearchRequestDto;
+import com.devsquad10.hub.domain.model.HubRoute;
+import com.devsquad10.hub.domain.model.QHubRoute;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class HubRouteRepositoryCustomImpl implements HubRouteRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	QHubRoute hubRoute = QHubRoute.hubRoute;
+
+	@Override
+	public Page<HubRoute> findAll(HubRouteSearchRequestDto request) {
+
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (request.getId() != null) {
+			builder.and(hubRoute.id.eq(request.getId()));
+		}
+
+		if (request.getDepartureHubId() != null) {
+			builder.and(hubRoute.departureHub.id.eq(request.getDepartureHubId()));
+		}
+
+		if (request.getDestinationHubId() != null) {
+			builder.and(hubRoute.destinationHub.id.eq(request.getDestinationHubId()));
+		}
+
+		if (StringUtils.hasText(request.getDepartureHubName())) {
+			builder.and(hubRoute.departureHub.name.containsIgnoreCase(request.getDepartureHubName()));
+		}
+
+		if (StringUtils.hasText(request.getDestinationHubName())) {
+			builder.and(hubRoute.destinationHub.name.containsIgnoreCase(request.getDestinationHubName()));
+		}
+
+		if (request.getMinDistance() != null) {
+			builder.and(hubRoute.distance.goe(request.getMinDistance()));
+		}
+
+		if (request.getMaxDistance() != null) {
+			builder.and(hubRoute.distance.loe(request.getMaxDistance()));
+		}
+
+		if (request.getMinDuration() != null) {
+			builder.and(hubRoute.duration.goe(request.getMinDuration()));
+		}
+
+		if (request.getMaxDuration() != null) {
+			builder.and(hubRoute.duration.loe(request.getMaxDuration()));
+		}
+
+		List<HubRoute> data = queryFactory.select(hubRoute).from(hubRoute)
+			.where(builder)
+			.offset((long)request.getPage() * request.getSize())
+			.limit(request.getSize())
+			.orderBy(getOrderSpecifier(request.getSortOption(), request.getSortOrder()))
+			.fetch();
+
+		Long total = queryFactory.select(hubRoute.count())
+			.from(hubRoute)
+			.where(builder)
+			.fetchOne();
+
+		return new PageImpl<>(
+			data,
+			PageRequest.of(request.getPage(), request.getSize()),
+			total != null ? total : 0L
+		);
+	}
+
+	private OrderSpecifier<?> getOrderSpecifier(HubRouteSortOption sortOption, Sort.Direction direction) {
+		switch (sortOption) {
+			case CREATED_AT:
+				return direction == Sort.Direction.ASC ? hubRoute.createdAt.asc() : hubRoute.createdAt.desc();
+			case UPDATED_AT:
+				return direction == Sort.Direction.ASC ? hubRoute.updatedAt.asc() : hubRoute.updatedAt.desc();
+			case DISTANCE:
+				return direction == Sort.Direction.ASC ? hubRoute.distance.asc() : hubRoute.distance.desc();
+			case DURATION:
+				return direction == Sort.Direction.ASC ? hubRoute.duration.asc() : hubRoute.duration.desc();
+			default:
+				return hubRoute.createdAt.asc();
+		}
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/JpaHubRouteRepository.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/JpaHubRouteRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 import com.devsquad10.hub.domain.model.HubRoute;
 
 @Repository
-public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID> {
+public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID>, HubRouteRepositoryCustom {
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/JpaHubRouteRepository.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/JpaHubRouteRepository.java
@@ -1,0 +1,12 @@
+package com.devsquad10.hub.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.devsquad10.hub.domain.model.HubRoute;
+
+@Repository
+public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID> {
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
@@ -1,7 +1,11 @@
 package com.devsquad10.hub.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
 import com.devsquad10.hub.application.dto.res.ApiResponse;
 import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
+import com.devsquad10.hub.application.dto.res.HubRouteGetOneResponseDto;
 import com.devsquad10.hub.application.service.HubRouteService;
 
 import jakarta.validation.Valid;
@@ -27,6 +32,19 @@ public class HubRouteController {
 		@Valid @RequestBody HubRouteCreateRequestDto request
 	) {
 		HubRouteCreateResponseDto response = hubRouteService.createHubRoute(request);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				HttpStatus.OK.value(),
+				response
+			));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse<HubRouteGetOneResponseDto>> getHubRoute(
+		@PathVariable UUID id
+	) {
+		HubRouteGetOneResponseDto response = hubRouteService.getOneHubRoute(id);
 
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.success(

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
@@ -1,0 +1,37 @@
+package com.devsquad10.hub.presentation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
+import com.devsquad10.hub.application.dto.res.ApiResponse;
+import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
+import com.devsquad10.hub.application.service.HubRouteService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/hub-route")
+public class HubRouteController {
+
+	private final HubRouteService hubRouteService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<HubRouteCreateResponseDto>> createHubRoute(
+		@Valid @RequestBody HubRouteCreateRequestDto request
+	) {
+		HubRouteCreateResponseDto response = hubRouteService.createHubRoute(request);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				HttpStatus.OK.value(),
+				response
+			));
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,11 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
+import com.devsquad10.hub.application.dto.req.HubRouteSearchRequestDto;
 import com.devsquad10.hub.application.dto.req.HubRouteUpdateRequestDto;
 import com.devsquad10.hub.application.dto.res.ApiResponse;
 import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
 import com.devsquad10.hub.application.dto.res.HubRouteGetOneResponseDto;
 import com.devsquad10.hub.application.dto.res.HubRouteUpdateResponseDto;
+import com.devsquad10.hub.application.dto.res.PagedHubRouteResponseDto;
 import com.devsquad10.hub.application.service.HubRouteService;
 
 import jakarta.validation.Valid;
@@ -80,6 +83,19 @@ public class HubRouteController {
 			.body(ApiResponse.success(
 				HttpStatus.OK.value(),
 				"HubRoute successfully deleted"
+			));
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<PagedHubRouteResponseDto>> getAllHubs(
+		@ModelAttribute @Valid HubRouteSearchRequestDto request
+	) {
+		PagedHubRouteResponseDto response = hubRouteService.getHub(request);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				HttpStatus.OK.value(),
+				response
 			));
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,6 +68,18 @@ public class HubRouteController {
 			.body(ApiResponse.success(
 				HttpStatus.OK.value(),
 				response
+			));
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<ApiResponse<String>> deleteHubRoute(
+		@PathVariable UUID id
+	) {
+		hubRouteService.deleteHubRoute(id);
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				HttpStatus.OK.value(),
+				"HubRoute successfully deleted"
 			));
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,9 +13,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.devsquad10.hub.application.dto.req.HubRouteCreateRequestDto;
+import com.devsquad10.hub.application.dto.req.HubRouteUpdateRequestDto;
 import com.devsquad10.hub.application.dto.res.ApiResponse;
 import com.devsquad10.hub.application.dto.res.HubRouteCreateResponseDto;
 import com.devsquad10.hub.application.dto.res.HubRouteGetOneResponseDto;
+import com.devsquad10.hub.application.dto.res.HubRouteUpdateResponseDto;
 import com.devsquad10.hub.application.service.HubRouteService;
 
 import jakarta.validation.Valid;
@@ -45,6 +48,20 @@ public class HubRouteController {
 		@PathVariable UUID id
 	) {
 		HubRouteGetOneResponseDto response = hubRouteService.getOneHubRoute(id);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				HttpStatus.OK.value(),
+				response
+			));
+	}
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<ApiResponse<HubRouteUpdateResponseDto>> updateHubRoute(
+		@PathVariable UUID id,
+		@Valid @RequestBody HubRouteUpdateRequestDto request
+	) {
+		HubRouteUpdateResponseDto response = hubRouteService.updateHubRoute(id, request);
 
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.success(

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/handler/HubRouteExceptionHandler.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/handler/HubRouteExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.devsquad10.hub.presentation.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.devsquad10.hub.application.dto.res.ApiResponse;
+import com.devsquad10.hub.application.exception.HubRouteNotFoundException;
+
+@RestControllerAdvice
+public class HubRouteExceptionHandler {
+	// TODO: custom error code로 설정
+	@ExceptionHandler(HubRouteNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public ResponseEntity<ApiResponse<String>> handleHubRouteNotFoundException(HubRouteNotFoundException e) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(ApiResponse.failure(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+	}
+
+	@ExceptionHandler(Exception.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	public ResponseEntity<ApiResponse<String>> handleHubRouteUnexpectedException(Exception e) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ApiResponse.failure(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage()));
+	}
+}


### PR DESCRIPTION
## 변경 타입
 - [X] 신규 기능 추가/수정
 - [ ] 버그 수정
 - [ ] 리팩토링
 - [ ] 설정
 - [ ] 비기능 (주석 등 기능에 영향을 주지 않음)
 
 ## 변경 내용
 - **as-is**
   - 초기 허브 이동 경로 도메인 구현 없음
 
 - **to-be**
   - 허브 이동 경로(HubRoute) 도메인 CRUD + Pagination/Search 기능 구현
     - `/api/hub-route/` 경로의 POST, GET, PATCH, DELETE 요청
   - 캐싱 구현
   - 논리적 삭제(Soft Delete) 구현
   - QueryDSL을 활용한 동적 검색 기능 구현

 ## 코멘트
 - **추가 개선점**
   - 경로 알고리즘 구현
   - 경유지 추가
   - 캐시 무효화 로직 보완 필요
 
 ## 관련 이슈
 <!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#48