### PR TITLE
#68 Hub간 P2P 이동 경로 계산 구현

### DIFF
--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteCreateResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteCreateResponseDto.java
@@ -1,7 +1,6 @@
 package com.devsquad10.hub.application.dto.res;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import com.devsquad10.hub.domain.model.HubRoute;
@@ -27,9 +26,8 @@ public class HubRouteCreateResponseDto {
 	private Integer duration;
 	private LocalDateTime createdAt;
 	private UUID createdBy;
-	private List<UUID> waypoints;
 
-	public static HubRouteCreateResponseDto toResponseDto(HubRoute hubRoute, List<UUID> waypoints) {
+	public static HubRouteCreateResponseDto toResponseDto(HubRoute hubRoute) {
 		return HubRouteCreateResponseDto.builder()
 			.id(hubRoute.getId())
 			.departureHubId(hubRoute.getDepartureHub().getId())
@@ -40,7 +38,6 @@ public class HubRouteCreateResponseDto {
 			.duration(hubRoute.getDuration())
 			.createdAt(hubRoute.getCreatedAt())
 			.createdBy(hubRoute.getCreatedBy())
-			.waypoints(waypoints)
 			.build();
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteUpdateResponseDto.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/dto/res/HubRouteUpdateResponseDto.java
@@ -1,7 +1,6 @@
 package com.devsquad10.hub.application.dto.res;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import com.devsquad10.hub.domain.model.HubRoute;
@@ -23,9 +22,8 @@ public class HubRouteUpdateResponseDto {
 	private Integer duration;
 	private LocalDateTime updatedAt;
 	private UUID updatedBy;
-	private List<UUID> waypoints;  // 경유지 정보
 
-	public static HubRouteUpdateResponseDto toResponseDto(HubRoute hubRoute, List<UUID> waypoints) {
+	public static HubRouteUpdateResponseDto toResponseDto(HubRoute hubRoute) {
 		return HubRouteUpdateResponseDto.builder()
 			.id(hubRoute.getId())
 			.departureHubId(hubRoute.getDepartureHub().getId())
@@ -36,7 +34,6 @@ public class HubRouteUpdateResponseDto {
 			.duration(hubRoute.getDuration())
 			.updatedAt(hubRoute.getUpdatedAt())
 			.updatedBy(hubRoute.getUpdatedBy())
-			.waypoints(waypoints)
 			.build();
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteCalculateStrategy.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteCalculateStrategy.java
@@ -3,6 +3,8 @@ package com.devsquad10.hub.application.service;
 import com.devsquad10.hub.application.dto.RouteCalculationResult;
 import com.devsquad10.hub.domain.model.Hub;
 
-public interface HubRouteCalculateService {
+public interface HubRouteCalculateStrategy {
 	RouteCalculationResult calculateRoute(Hub departureHub, Hub destinationHub);
+
+	RouteCalculationResult calculateRouteWithApi(Hub departureHub, Hub destinationHub);
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -1,7 +1,5 @@
 package com.devsquad10.hub.application.service;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.cache.annotation.CacheEvict;
@@ -37,7 +35,7 @@ public class HubRouteService {
 
 	private final HubRepository hubRepository;
 	private final HubRouteRepository hubRouteRepository;
-	private final HubRouteCalculateService hubRouteCalculateService;
+	private final HubRouteCalculateStrategy hubRouteCalculateStrategy;
 
 	@Caching(evict = {
 		@CacheEvict(value = "hubRouteSearchCache", allEntries = true)
@@ -50,7 +48,8 @@ public class HubRouteService {
 			.orElseThrow(() -> new HubNotFoundException("도착 허브를 찾을 수 없습니다. ID: " + request.getDestinationHubId()));
 
 		RouteCalculationResult calculationResult =
-			hubRouteCalculateService.calculateRoute(departureHub, destinationHub);
+			// hubRouteCalculateService.calculateRoute(departureHub, destinationHub);
+			hubRouteCalculateStrategy.calculateRouteWithApi(departureHub, destinationHub);
 
 		HubRoute hubRoute = HubRoute.builder()
 			.departureHub(departureHub)
@@ -81,27 +80,14 @@ public class HubRouteService {
 		HubRoute hubRoute = hubRouteRepository.findById(id)
 			.orElseThrow(() -> new HubRouteNotFoundException("허브 경로를 찾을 수 없습니다."));
 
-		RouteCalculationResult calculationResult =
-			hubRouteCalculateService.calculateRoute(hubRoute.getDepartureHub(), hubRoute.getDestinationHub());
-
 		hubRoute.update(
-			// TODO: 임시 값 설정
-			// calculationResult.getDistance(),
-			// calculationResult.getDuration()
-			(Math.random() * 10000),
-			((int)(Math.random() * 1000000))
+			request.getDistance(),
+			request.getDuration()
 		);
-
-		// TODO: 임시 값 설정
-		List<UUID> dummyList = new ArrayList<>();
-		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111101"));
-		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111102"));
-		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111103"));
 
 		HubRoute updatedRoute = hubRouteRepository.save(hubRoute);
 
-		// return HubRouteUpdateResponseDto.toResponseDto(updatedRoute, calculationResult.getWaypoints());
-		return HubRouteUpdateResponseDto.toResponseDto(updatedRoute, dummyList);
+		return HubRouteUpdateResponseDto.toResponseDto(updatedRoute);
 	}
 
 	@Caching(evict = {

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -55,23 +55,13 @@ public class HubRouteService {
 		HubRoute hubRoute = HubRoute.builder()
 			.departureHub(departureHub)
 			.destinationHub(destinationHub)
-			// TODO: 임시 값 설정
-			// .distance(calculationResult.getDistance())
-			// .duration(calculationResult.getDuration())
-			.distance(Math.random() * 10000)
-			.duration((int)(Math.random() * 1000000))
+			.distance(calculationResult.getDistance())
+			.duration(calculationResult.getDuration())
 			.build();
 
 		HubRoute savedRoute = hubRouteRepository.save(hubRoute);
 
-		// TODO: 임시 값 설정
-		List<UUID> dummyList = new ArrayList<>();
-		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111101"));
-		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111102"));
-		dummyList.add(UUID.fromString("11111111-1111-1111-1111-111111111103"));
-
-		// return HubRouteCreateResponseDto.toResponseDto(savedRoute, calculationResult.getWaypoints());
-		return HubRouteCreateResponseDto.toResponseDto(savedRoute, dummyList);
+		return HubRouteCreateResponseDto.toResponseDto(savedRoute, calculationResult.getWaypoints());
 	}
 
 	@Transactional(readOnly = true)

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubRouteService.java
@@ -56,7 +56,7 @@ public class HubRouteService {
 			return HubRouteCreateResponseDto.toResponseDto(existingRoute.get());
 		}
 		RouteCalculationResult calculationResult =
-			// hubRouteCalculateService.calculateRoute(departureHub, destinationHub);
+			// hubRouteCalculateStrategy.calculateRoute(departureHub, destinationHub);
 			hubRouteCalculateStrategy.calculateRouteWithApi(departureHub, destinationHub);
 
 		HubRoute newHubRoute = HubRoute.builder()

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubToHubRelayCalculateStrategy.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/HubToHubRelayCalculateStrategy.java
@@ -3,7 +3,12 @@ package com.devsquad10.hub.application.service;
 import com.devsquad10.hub.application.dto.RouteCalculationResult;
 import com.devsquad10.hub.domain.model.Hub;
 
-public class HubToHubRelayCalculateService implements HubRouteCalculateService {
+public class HubToHubRelayCalculateStrategy implements HubRouteCalculateStrategy {
+	@Override
+	public RouteCalculationResult calculateRouteWithApi(Hub departureHub, Hub destinationHub) {
+		return null;
+	}
+
 	@Override
 	public RouteCalculationResult calculateRoute(Hub departureHub, Hub destinationHub) {
 		return null;

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateService.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateService.java
@@ -1,5 +1,7 @@
 package com.devsquad10.hub.application.service;
 
+import java.util.Collections;
+
 import org.springframework.stereotype.Service;
 
 import com.devsquad10.hub.application.dto.RouteCalculationResult;
@@ -9,6 +11,42 @@ import com.devsquad10.hub.domain.model.Hub;
 public class P2PRouteCalculateService implements HubRouteCalculateService {
 	@Override
 	public RouteCalculationResult calculateRoute(Hub departureHub, Hub destinationHub) {
-		return null;
+
+		// 하버사인 공식을 이용한 거리 계산(미터 단위)
+		double distance = calculateHaversineDistance(
+			departureHub.getLatitude(), departureHub.getLongitude(),
+			destinationHub.getLatitude(), destinationHub.getLongitude()
+		);
+
+		// 평균 50km/h로 이동 한다 가정 할 경우 예상 시간(밀리 초)
+		int durationInMillis = (int)(distance / 50.0 * 3600);
+
+		return RouteCalculationResult.builder()
+			.distance(distance)
+			.duration(durationInMillis)
+			.waypoints(Collections.emptyList())
+			.build();
+	}
+
+	/**
+	 * 하버사인 공식을 사용한 두 지점 간 거리 계산
+	 * @param lat1 위도1
+	 * @param lon1 경도1
+	 * @param lat2 위도2
+	 * @param lon2 경도2
+	 * @return 두 좌표의 거리 (미터 단위)
+	 */
+	private double calculateHaversineDistance(double lat1, double lon1, double lat2, double lon2) {
+		final double R = 6378.137;
+
+		double dLat = Math.toRadians(lat2 - lat1);
+		double dLon = Math.toRadians(lon2 - lon1);
+
+		double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+			Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+		double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+		return R * c * 1000;
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateStrategy.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateStrategy.java
@@ -6,12 +6,19 @@ import org.springframework.stereotype.Service;
 
 import com.devsquad10.hub.application.dto.RouteCalculationResult;
 import com.devsquad10.hub.domain.model.Hub;
+import com.devsquad10.hub.infrastructure.client.NaverDirections5Client;
+import com.devsquad10.hub.infrastructure.client.dto.NaverDirections5Response;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
-public class P2PRouteCalculateService implements HubRouteCalculateService {
+@RequiredArgsConstructor
+public class P2PRouteCalculateStrategy implements HubRouteCalculateStrategy {
+
+	private final NaverDirections5Client naverClient;
+
 	@Override
 	public RouteCalculationResult calculateRoute(Hub departureHub, Hub destinationHub) {
-
 		// 하버사인 공식을 이용한 거리 계산(미터 단위)
 		double distance = calculateHaversineDistance(
 			departureHub.getLatitude(), departureHub.getLongitude(),
@@ -28,6 +35,20 @@ public class P2PRouteCalculateService implements HubRouteCalculateService {
 			.build();
 	}
 
+	@Override
+	public RouteCalculationResult calculateRouteWithApi(Hub departureHub, Hub destinationHub) {
+		NaverDirections5Response apiResult = naverClient.getDistanceAndDuration(
+			departureHub.getLatitude(), departureHub.getLongitude(),
+			destinationHub.getLatitude(), destinationHub.getLongitude()
+		);
+
+		return RouteCalculationResult.builder()
+			.distance(Double.valueOf(apiResult.getDistance()))
+			.duration(apiResult.getDuration())
+			.waypoints(Collections.emptyList())
+			.build();
+	}
+
 	/**
 	 * 하버사인 공식을 사용한 두 지점 간 거리 계산
 	 * @param lat1 위도1
@@ -37,14 +58,15 @@ public class P2PRouteCalculateService implements HubRouteCalculateService {
 	 * @return 두 좌표의 거리 (미터 단위)
 	 */
 	private double calculateHaversineDistance(double lat1, double lon1, double lat2, double lon2) {
-		final double R = 6378.137;
+		final double R = 6378.137; // 지구 반지름 길이(km)
 
-		double dLat = Math.toRadians(lat2 - lat1);
-		double dLon = Math.toRadians(lon2 - lon1);
+		double dLat = Math.toRadians(lat2 - lat1); // 위도 차
+		double dLon = Math.toRadians(lon2 - lon1); // 경도 차
 
-		double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-			Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+		double a = Math.pow(Math.sin(dLat / 2), 2) + Math.cos(Math.toRadians(lat1))
+			* Math.cos(Math.toRadians(lat2)) * Math.pow(Math.sin(dLon / 2), 2);
 
+		// 원래 공식인 2·r·arcsin(√a) 대신 2·atan2(√a, √(1–a))가 오차 전파가 적어 안정적임
 		double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
 		return R * c * 1000;

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateStrategy.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/application/service/P2PRouteCalculateStrategy.java
@@ -25,8 +25,11 @@ public class P2PRouteCalculateStrategy implements HubRouteCalculateStrategy {
 			destinationHub.getLatitude(), destinationHub.getLongitude()
 		);
 
-		// 평균 50km/h로 이동 한다 가정 할 경우 예상 시간(밀리 초)
-		int durationInMillis = (int)(distance / 50.0 * 3600);
+		// 평균 50km/h로 이동 한다 가정
+		final double SPEED_KMH = 50.0;
+
+		// 이동 예상 시간 (밀리 초)
+		int durationInMillis = (int)((distance * 0.001) / SPEED_KMH * (3600 * 1000));
 
 		return RouteCalculationResult.builder()
 			.distance(distance)

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepository.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepository.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 
 import com.devsquad10.hub.application.dto.req.HubRouteSearchRequestDto;
+import com.devsquad10.hub.domain.model.Hub;
 import com.devsquad10.hub.domain.model.HubRoute;
 
 public interface HubRouteRepository {
@@ -14,4 +15,6 @@ public interface HubRouteRepository {
 	Optional<HubRoute> findById(UUID id);
 
 	Page<HubRoute> findAll(HubRouteSearchRequestDto request);
+
+	Optional<HubRoute> findByDepartureHubAndDestinationHub(Hub departureHub, Hub destinationHub);
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/domain/repository/HubRouteRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
 import com.devsquad10.hub.application.dto.req.HubRouteSearchRequestDto;
+import com.devsquad10.hub.domain.model.Hub;
 import com.devsquad10.hub.domain.model.HubRoute;
 import com.devsquad10.hub.infrastructure.repository.JpaHubRouteRepository;
 
@@ -31,5 +32,10 @@ public class HubRouteRepositoryImpl implements HubRouteRepository {
 	@Override
 	public Page<HubRoute> findAll(HubRouteSearchRequestDto request) {
 		return jpaHubRouteRepository.findAll(request);
+	}
+
+	@Override
+	public Optional<HubRoute> findByDepartureHubAndDestinationHub(Hub departureHub, Hub destinationHub) {
+		return jpaHubRouteRepository.findByDepartureHubAndDestinationHub(departureHub, destinationHub);
 	}
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/NaverDirections5Client.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/NaverDirections5Client.java
@@ -1,0 +1,84 @@
+package com.devsquad10.hub.infrastructure.client;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.devsquad10.hub.infrastructure.client.dto.NaverDirections5Response;
+import com.devsquad10.hub.infrastructure.client.exception.RestClientApiCallException;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * NAVER Directions 5 API 참고
+ * @link <a href="https://api.ncloud-docs.com/docs/ai-naver-mapsdirections-driving">
+ * NAVER Directions 5 API
+ * </a>
+ */
+@Component
+@RequiredArgsConstructor
+public class NaverDirections5Client {
+
+	private final RestClient restClient;
+
+	@Value("${naver.api.client-id}")
+	private String clientId;
+
+	@Value("${naver.api.client-secret}")
+	private String clientSecret;
+
+	@Value("${naver.api.url}")
+	private String clientUrl;
+
+	public NaverDirections5Response getDistanceAndDuration(
+		Double latitude,
+		Double longitude,
+		Double destinationHubLatitude,
+		Double destinationHubLongitude
+	) {
+
+		URI url = UriComponentsBuilder.fromUriString(clientUrl)
+			.queryParam("start", longitude + "," + latitude)
+			.queryParam("goal", destinationHubLongitude + "," + destinationHubLatitude)
+			.build()
+			.toUri();
+
+		ResponseEntity<String> response = restClient.get()
+			.uri(url)
+			.headers(headers -> {
+				headers.set("x-ncp-apigw-api-key-id", clientId);
+				headers.set("x-ncp-apigw-api-key", clientSecret);
+				headers.setContentType(MediaType.APPLICATION_JSON);
+			})
+			.retrieve()
+			.toEntity(String.class);
+
+		return parseResponse(response.getBody());
+	}
+
+	private NaverDirections5Response parseResponse(String responseBody) {
+		try {
+			JSONObject jsonResponse = new JSONObject(responseBody);
+			JSONObject summary = jsonResponse.getJSONObject("route")
+				.getJSONArray("traoptimal")
+				.getJSONObject(0)
+				.getJSONObject("summary");
+
+			Integer distance = summary.getInt("distance");
+			Integer duration = summary.getInt("duration");
+
+			return NaverDirections5Response.builder()
+				.distance(distance)
+				.duration(duration)
+				.build();
+		} catch (Exception e) {
+			throw new RestClientApiCallException("API 응답 파싱 실패: " + e.getMessage());
+		}
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/dto/NaverDirections5Response.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/dto/NaverDirections5Response.java
@@ -1,0 +1,11 @@
+package com.devsquad10.hub.infrastructure.client.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NaverDirections5Response {
+	private Integer distance;
+	private Integer duration;
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/exception/RestClientApiCallException.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/exception/RestClientApiCallException.java
@@ -1,0 +1,7 @@
+package com.devsquad10.hub.infrastructure.client.exception;
+
+public class RestClientApiCallException extends RuntimeException {
+	public RestClientApiCallException(String message) {
+		super(message);
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/exception/RestClientApiServerErrorException.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/client/exception/RestClientApiServerErrorException.java
@@ -1,0 +1,7 @@
+package com.devsquad10.hub.infrastructure.client.exception;
+
+public class RestClientApiServerErrorException extends RuntimeException {
+	public RestClientApiServerErrorException(String message) {
+		super(message);
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/config/RestClientConfig.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/config/RestClientConfig.java
@@ -1,0 +1,46 @@
+package com.devsquad10.hub.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import com.devsquad10.hub.infrastructure.client.exception.RestClientApiCallException;
+import com.devsquad10.hub.infrastructure.client.exception.RestClientApiServerErrorException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+public class RestClientConfig {
+	@Bean
+	public RestClient restClient() {
+		return RestClient.builder()
+			.defaultHeaders(headers -> {
+				headers.setContentType(MediaType.APPLICATION_JSON);
+			})
+			.requestFactory(getClientHttpRequestFactory())
+			.defaultStatusHandler(HttpStatusCode::is4xxClientError, (req, res) -> {
+				log.error("4xx Error - URL: {}, Status: {}, Body: {}",
+					req.getURI(), res.getStatusCode(), res.getBody());
+				throw new RestClientApiCallException(res.getStatusText());
+			})
+			.defaultStatusHandler(HttpStatusCode::is5xxServerError, (req, res) -> {
+				log.error("5xx Error - URL: {}, Status: {}, Body: {}",
+					req.getURI(), res.getStatusCode(), res.getBody());
+				throw new RestClientApiServerErrorException(res.getStatusText());
+			})
+			.build();
+	}
+
+	private ClientHttpRequestFactory getClientHttpRequestFactory() {
+		SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+		factory.setConnectTimeout(10000);
+		factory.setReadTimeout(10000);
+
+		return factory;
+	}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/JpaHubRouteRepository.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/infrastructure/repository/JpaHubRouteRepository.java
@@ -1,12 +1,15 @@
 package com.devsquad10.hub.infrastructure.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.devsquad10.hub.domain.model.Hub;
 import com.devsquad10.hub.domain.model.HubRoute;
 
 @Repository
 public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID>, HubRouteRepositoryCustom {
+	Optional<HubRoute> findByDepartureHubAndDestinationHub(Hub departureHub, Hub destinationHub);
 }


### PR DESCRIPTION
## 변경 타입
 - [X] 신규 기능 추가/수정
 - [ ] 버그 수정
 - [ ] 리팩토링
 - [ ] 설정
 - [ ] 비기능 (주석 등 기능에 영향을 주지 않음)
 
 ## 변경 내용
 - **as-is**
 
 - **to-be**
   - 허브 이동 경로(HubRoute) P2P 이동 경로 구현
   - 경로 계산에 Naver Directions 5 API 연동

 ## 코멘트
 **naver maps api에 호출 횟수 제한이 있습니다 (6만회 제한)**

 **hub모듈의 application.yml 설정** 
```
naver:
  api:
    client-id: ${NAVER_API_CLIENT_ID}
    client-secret: ${NAVER_API_CLIENT_SECRET}
    url: https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving
```
 
 ## 관련 이슈
 <!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#68 #69