### PR TITLE
#2 Company refactor 

### DIFF
--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
@@ -17,6 +17,7 @@ import com.devsquad10.company.application.dto.CompanyResDto;
 import com.devsquad10.company.application.exception.CompanyNotFoundException;
 import com.devsquad10.company.domain.enums.CompanyTypes;
 import com.devsquad10.company.domain.model.Company;
+import com.devsquad10.company.domain.repository.CompanyQuerydslRepository;
 import com.devsquad10.company.domain.repository.CompanyRepository;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -28,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class CompanyService {
 
 	private final CompanyRepository companyRepository;
+	private final CompanyQuerydslRepository companyQuerydslRepository;
 	private final HubClient hubClient;
 
 	@CachePut(cacheNames = "companyCache", key = "#result.id")
@@ -62,7 +64,7 @@ public class CompanyService {
 	public Page<CompanyResDto> searchCompanies(String q, String category, int page, int size, String sort,
 		String order) {
 
-		Page<Company> companyPages = companyRepository.findAll(q, category, page, size, sort, order);
+		Page<Company> companyPages = companyQuerydslRepository.findAll(q, category, page, size, sort, order);
 
 		return companyPages.map(Company::toResponseDto);
 

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
@@ -116,6 +116,6 @@ public class CompanyService {
 	public String getCompanyAddress(UUID id) {
 		Company company = companyRepository.findByIdAndDeletedAtIsNull(id)
 			.orElse(null);
-		return (company != null) ? company.getAddress() : null;
+		return (company != null && company.getType().equals(CompanyTypes.RECIPIENTS)) ? company.getAddress() : null;
 	}
 }

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
@@ -15,6 +15,7 @@ import com.devsquad10.company.application.client.HubClient;
 import com.devsquad10.company.application.dto.CompanyReqDto;
 import com.devsquad10.company.application.dto.CompanyResDto;
 import com.devsquad10.company.application.exception.CompanyNotFoundException;
+import com.devsquad10.company.domain.enums.CompanyTypes;
 import com.devsquad10.company.domain.model.Company;
 import com.devsquad10.company.domain.repository.CompanyRepository;
 
@@ -109,7 +110,7 @@ public class CompanyService {
 	public UUID getHubIdIfCompanyExists(UUID id) {
 		Company company = companyRepository.findByIdAndDeletedAtIsNull(id)
 			.orElse(null);
-		return (company != null) ? company.getHubId() : null;
+		return (company != null && company.getType().equals(CompanyTypes.SUPPLIER)) ? company.getHubId() : null;
 	}
 
 	public String getCompanyAddress(UUID id) {

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/domain/repository/CompanyQuerydslRepository.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/domain/repository/CompanyQuerydslRepository.java
@@ -1,0 +1,9 @@
+package com.devsquad10.company.domain.repository;
+
+import org.springframework.data.domain.Page;
+
+import com.devsquad10.company.domain.model.Company;
+
+public interface CompanyQuerydslRepository {
+	Page<Company> findAll(String q, String category, int page, int size, String sort, String order);
+}

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/domain/repository/CompanyRepository.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/domain/repository/CompanyRepository.java
@@ -3,8 +3,6 @@ package com.devsquad10.company.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-
 import com.devsquad10.company.domain.model.Company;
 
 public interface CompanyRepository {
@@ -13,5 +11,4 @@ public interface CompanyRepository {
 
 	Company save(Company company);
 
-	Page<Company> findAll(String q, String category, int page, int size, String sort, String order);
 }

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/infrastructure/repository/CompanyQuerydslRepositoryCustom.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/infrastructure/repository/CompanyQuerydslRepositoryCustom.java
@@ -1,0 +1,103 @@
+package com.devsquad10.company.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.stereotype.Repository;
+
+import com.devsquad10.company.domain.model.Company;
+import com.devsquad10.company.domain.model.QCompany;
+import com.devsquad10.company.domain.repository.CompanyQuerydslRepository;
+import com.querydsl.core.BooleanBuilder;
+
+@Repository
+public interface CompanyQuerydslRepositoryCustom
+	extends JpaRepository<Company, UUID>, QuerydslPredicateExecutor<Company>, CompanyQuerydslRepository {
+	default Page<Company> findAll(String query, String category, int page, int size, String sortBy,
+		String order) {
+
+		size = validateSize(size);
+
+		QCompany company = QCompany.company;
+
+		// 검색 조건 생성
+		BooleanBuilder builder = buildSearchConditions(query, category, company);
+
+		Sort sort = getSortOrder(sortBy, order);
+
+		PageRequest pageRequest = PageRequest.of(page, size, sort);
+
+		return findAll(builder, pageRequest);
+
+	}
+
+	private BooleanBuilder buildSearchConditions(String query, String category, QCompany qCompany) {
+
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(qCompany.deletedBy.isNull());
+
+		if (query == null || query.isEmpty()) {
+			return builder;
+		}
+
+		if (category == null || category.isEmpty()) {
+			// 카테고리 지정이 없으면 모든 필드에서 검색
+			builder.or(qCompany.name.containsIgnoreCase(query));
+			builder.or(qCompany.address.containsIgnoreCase(query));
+			builder.or(qCompany.type.stringValue().containsIgnoreCase(query));
+		} else {
+			switch (category) {
+				case "name":
+					builder.or(qCompany.name.containsIgnoreCase(query));
+					break;
+				case "address":
+					builder.or(qCompany.address.containsIgnoreCase(query));
+					break;
+				case "type":
+					builder.or(qCompany.type.stringValue().containsIgnoreCase(query));
+					break;
+				default:
+					builder.or(qCompany.name.containsIgnoreCase(query));
+					builder.or(qCompany.address.containsIgnoreCase(query));
+					builder.or(qCompany.type.stringValue().containsIgnoreCase(query));
+					break;
+			}
+		}
+
+		return builder;
+	}
+
+	private int validateSize(int size) {
+		if (size != 10 && size != 30 && size != 50) {
+			size = 10;
+		}
+		return size;
+	}
+
+	private Sort getSortOrder(String sortBy, String order) {
+
+		if (!isValidSortBy(sortBy)) {
+			throw new IllegalArgumentException("SortBy 는 'createdAt', 'updatedAt', 'deletedAt' 값만 허용합니다.");
+		}
+
+		Sort sort = Sort.by(Sort.Order.by(sortBy));
+
+		sort = getSortDirection(sort, order);
+
+		return sort;
+	}
+
+	private boolean isValidSortBy(String sortBy) {
+
+		return "createdAt".equals(sortBy) || "updatedAt".equals(sortBy) || "deletedAt".equals(sortBy);
+	}
+
+	private Sort getSortDirection(Sort sort, String order) {
+		return "desc".equals(order) ? sort.descending() : sort.ascending();
+	}
+}

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/infrastructure/repository/JpaCompanyRepository.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/infrastructure/repository/JpaCompanyRepository.java
@@ -2,94 +2,14 @@ package com.devsquad10.company.infrastructure.repository;
 
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 import com.devsquad10.company.domain.model.Company;
-import com.devsquad10.company.domain.model.QCompany;
 import com.devsquad10.company.domain.repository.CompanyRepository;
-import com.querydsl.core.BooleanBuilder;
 
 @Repository
 public interface JpaCompanyRepository
-	extends JpaRepository<Company, UUID>, QuerydslPredicateExecutor<Company>, CompanyRepository {
+	extends JpaRepository<Company, UUID>, CompanyRepository {
 
-	default Page<Company> findAll(String query, String category, int page, int size, String sortBy,
-		String order) {
-
-		QCompany company = QCompany.company;
-
-		// 검색 조건 생성
-		BooleanBuilder builder = buildSearchConditions(query, category, company);
-
-		Sort sort = getSortOrder(sortBy, order);
-
-		PageRequest pageRequest = PageRequest.of(page, size, sort);
-
-		return findAll(builder, pageRequest);
-
-	}
-
-	private BooleanBuilder buildSearchConditions(String query, String category, QCompany qCompany) {
-
-		BooleanBuilder builder = new BooleanBuilder();
-		
-		builder.and(qCompany.deletedBy.isNull());
-
-		if (query == null || query.isEmpty()) {
-			return builder;
-		}
-
-		if (category == null || category.isEmpty()) {
-			// 카테고리 지정이 없으면 모든 필드에서 검색
-			builder.or(qCompany.name.containsIgnoreCase(query));
-			builder.or(qCompany.address.containsIgnoreCase(query));
-			builder.or(qCompany.type.stringValue().containsIgnoreCase(query));
-		} else {
-			switch (category) {
-				case "name":
-					builder.or(qCompany.name.containsIgnoreCase(query));
-					break;
-				case "address":
-					builder.or(qCompany.address.containsIgnoreCase(query));
-					break;
-				case "type":
-					builder.or(qCompany.type.stringValue().containsIgnoreCase(query));
-					break;
-				default:
-					builder.or(qCompany.name.containsIgnoreCase(query));
-					builder.or(qCompany.address.containsIgnoreCase(query));
-					builder.or(qCompany.type.stringValue().containsIgnoreCase(query));
-					break;
-			}
-		}
-
-		return builder;
-	}
-
-	private Sort getSortOrder(String sortBy, String order) {
-
-		if (!isValidSortBy(sortBy)) {
-			throw new IllegalArgumentException("SortBy 는 'createdAt', 'updatedAt', 'deletedAt' 값만 허용합니다.");
-		}
-
-		Sort sort = Sort.by(Sort.Order.by(sortBy));
-
-		sort = getSortDirection(sort, order);
-
-		return sort;
-	}
-
-	private boolean isValidSortBy(String sortBy) {
-
-		return "createdAt".equals(sortBy) || "updatedAt".equals(sortBy) || "deletedAt".equals(sortBy);
-	}
-
-	private Sort getSortDirection(Sort sort, String order) {
-		return "desc".equals(order) ? sort.descending() : sort.ascending();
-	}
 }

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
@@ -78,7 +78,7 @@ public class CompanyController {
 	}
 
 	@GetMapping("/address/{id}")
-	String getCompanyAddress(@PathVariable UUID id) {
+	public String getCompanyAddress(@PathVariable UUID id) {
 		return companyService.getCompanyAddress(id);
 	}
 }


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  -  getHubIdIfCompanyExists 메서드 조건에 해당 업체의 타입이 공급업체인지 검사하는 조건이 없었음
  -  getCompanyAddress 메서드 조건에 해당 업체의 타입이 수령업체인지 검사하는 조건이 없었음
  - 하나의 JpaRepository에서 queryDSL의 기능까지 같이 구현되어있음
- **to-be**
  - getHubIdIfCompanyExists  ,  getCompanyAddress  타입 검사 조건 추가
  -  queyDSL 기능을 별도의 인터페이스와 구현체로 분리하여 코드 구조 개선
  - jpaRepository에서는 기존의 jpa기능만 처리하고, queryDSL 관련 로직은 별도의 구현체에 처리하도록 변경

## 코멘트

## 관련 이슈
#2