### PR TITLE
refactor: #10 Product JPA Repository와 QueryDSL 기능 분리

### DIFF
--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/application/service/ProductService.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/application/service/ProductService.java
@@ -3,8 +3,6 @@ package com.devsquad10.product.application.service;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -19,6 +17,7 @@ import com.devsquad10.product.application.dto.ProductResDto;
 import com.devsquad10.product.application.exception.ProductNotFoundException;
 import com.devsquad10.product.domain.enums.ProductStatus;
 import com.devsquad10.product.domain.model.Product;
+import com.devsquad10.product.domain.repository.ProductQuerydslRepository;
 import com.devsquad10.product.domain.repository.ProductRepository;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -29,11 +28,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class ProductService {
 
-	@Value("${stockMessage.queue.stock.response}")
-	public String queueResponseStock;
-
 	private final ProductRepository productRepository;
-	private final RabbitTemplate rabbitTemplate;
+	private final ProductQuerydslRepository productQuerydslRepository;
 	private final CompanyClient companyClient;
 
 	@CachePut(cacheNames = "productCache", key = "#result.id")
@@ -70,7 +66,7 @@ public class ProductService {
 	public Page<ProductResDto> searchProducts(String q, String category, int page, int size, String sort,
 		String order) {
 
-		Page<Product> productPages = productRepository.findAll(q, category, page, size, sort, order);
+		Page<Product> productPages = productQuerydslRepository.findAll(q, category, page, size, sort, order);
 
 		return productPages.map(Product::toResponseDto);
 	}

--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/domain/repository/ProductQuerydslRepository.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/domain/repository/ProductQuerydslRepository.java
@@ -1,0 +1,9 @@
+package com.devsquad10.product.domain.repository;
+
+import org.springframework.data.domain.Page;
+
+import com.devsquad10.product.domain.model.Product;
+
+public interface ProductQuerydslRepository {
+	Page<Product> findAll(String q, String category, int page, int size, String sort, String order);
+}

--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/domain/repository/ProductRepository.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/domain/repository/ProductRepository.java
@@ -3,8 +3,6 @@ package com.devsquad10.product.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-
 import com.devsquad10.product.domain.model.Product;
 
 public interface ProductRepository {
@@ -12,8 +10,6 @@ public interface ProductRepository {
 	Optional<Product> findByIdAndDeletedAtIsNull(UUID id);
 
 	Product save(Product product);
-
-	Page<Product> findAll(String q, String category, int page, int size, String sort, String order);
 
 	int decreaseStock(UUID productId, int orderQuantity);
 }

--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/infrastructure/repository/JpaProductRepository.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/infrastructure/repository/JpaProductRepository.java
@@ -2,9 +2,6 @@ package com.devsquad10.product.infrastructure.repository;
 
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,10 +9,7 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 import com.devsquad10.product.domain.model.Product;
-import com.devsquad10.product.domain.model.QProduct;
 import com.devsquad10.product.domain.repository.ProductRepository;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.ComparableExpressionBase;
 
 import jakarta.transaction.Transactional;
 
@@ -29,87 +23,4 @@ public interface JpaProductRepository
 		"WHERE p.id = :productId AND p.quantity >= :orderQuantity")
 	int decreaseStock(UUID productId, int orderQuantity);
 
-	default Page<Product> findAll(String query, String category, int page, int size, String sortBy,
-		String order) {
-
-		QProduct product = QProduct.product;
-
-		// 검색 조건 생성
-		BooleanBuilder builder = buildSearchConditions(query, category, product);
-
-		Sort sort = getSortOrder(sortBy, order);
-
-		PageRequest pageRequest = PageRequest.of(page, size, sort);
-
-		return findAll(builder, pageRequest);
-
-	}
-
-	private BooleanBuilder buildSearchConditions(String query, String category, QProduct qProduct) {
-
-		BooleanBuilder builder = new BooleanBuilder();
-
-		builder.and(qProduct.deletedAt.isNull());
-
-		if (query == null || query.isEmpty()) {
-			return builder;
-		}
-
-		if (category == null || category.isEmpty()) {
-			// 카테고리 지정이 없으면 모든 필드에서 검색
-			builder.or(qProduct.name.containsIgnoreCase(query));
-			builder.or(parseUUID(query, qProduct.supplierId));
-			builder.or(parseUUID(query, qProduct.hubId));
-		} else {
-			switch (category) {
-				case "name":
-					builder.or(qProduct.name.containsIgnoreCase(query));
-					break;
-				case "supplierId":
-					builder.or(parseUUID(query, qProduct.supplierId));
-					break;
-				case "hubId":
-					builder.or(parseUUID(query, qProduct.hubId));
-					break;
-				default:
-					builder.or(qProduct.name.containsIgnoreCase(query));
-					builder.or(parseUUID(query, qProduct.supplierId));
-					builder.or(parseUUID(query, qProduct.hubId));
-					break;
-			}
-		}
-
-		return builder;
-	}
-
-	private BooleanBuilder parseUUID(String query, ComparableExpressionBase<UUID> uuidField) {
-		try {
-			UUID uuidQuery = UUID.fromString(query);
-			return new BooleanBuilder(uuidField.eq(uuidQuery));
-		} catch (IllegalArgumentException e) {
-			return new BooleanBuilder(); // 잘못된 uuid이면 빈 조건 검색 반환 (검색 무시)
-		}
-	}
-
-	private Sort getSortOrder(String sortBy, String order) {
-
-		if (!isValidSortBy(sortBy)) {
-			throw new IllegalArgumentException("SortBy 는 'createdAt', 'updatedAt', 'deletedAt' 값만 허용합니다.");
-		}
-
-		Sort sort = Sort.by(Sort.Order.by(sortBy));
-
-		sort = getSortDirection(sort, order);
-
-		return sort;
-	}
-
-	private boolean isValidSortBy(String sortBy) {
-
-		return "createdAt".equals(sortBy) || "updatedAt".equals(sortBy) || "deletedAt".equals(sortBy);
-	}
-
-	private Sort getSortDirection(Sort sort, String order) {
-		return "desc".equals(order) ? sort.descending() : sort.ascending();
-	}
 }

--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/infrastructure/repository/ProductQuerydslRepositoryCustom.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/infrastructure/repository/ProductQuerydslRepositoryCustom.java
@@ -1,0 +1,112 @@
+package com.devsquad10.product.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+import com.devsquad10.product.domain.model.Product;
+import com.devsquad10.product.domain.model.QProduct;
+import com.devsquad10.product.domain.repository.ProductQuerydslRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+
+public interface ProductQuerydslRepositoryCustom extends
+	JpaRepository<Product, UUID>, QuerydslPredicateExecutor<Product>, ProductQuerydslRepository {
+
+	default Page<Product> findAll(String query, String category, int page, int size, String sortBy,
+		String order) {
+
+		size = validateSize(size);
+
+		QProduct product = QProduct.product;
+
+		// 검색 조건 생성
+		BooleanBuilder builder = buildSearchConditions(query, category, product);
+
+		Sort sort = getSortOrder(sortBy, order);
+
+		PageRequest pageRequest = PageRequest.of(page, size, sort);
+
+		return findAll(builder, pageRequest);
+
+	}
+
+	private BooleanBuilder buildSearchConditions(String query, String category, QProduct qProduct) {
+
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(qProduct.deletedAt.isNull());
+
+		if (query == null || query.isEmpty()) {
+			return builder;
+		}
+
+		if (category == null || category.isEmpty()) {
+			// 카테고리 지정이 없으면 모든 필드에서 검색
+			builder.or(qProduct.name.containsIgnoreCase(query));
+			builder.or(parseUUID(query, qProduct.supplierId));
+			builder.or(parseUUID(query, qProduct.hubId));
+		} else {
+			switch (category) {
+				case "name":
+					builder.or(qProduct.name.containsIgnoreCase(query));
+					break;
+				case "supplierId":
+					builder.or(parseUUID(query, qProduct.supplierId));
+					break;
+				case "hubId":
+					builder.or(parseUUID(query, qProduct.hubId));
+					break;
+				default:
+					builder.or(qProduct.name.containsIgnoreCase(query));
+					builder.or(parseUUID(query, qProduct.supplierId));
+					builder.or(parseUUID(query, qProduct.hubId));
+					break;
+			}
+		}
+
+		return builder;
+	}
+
+	private int validateSize(int size) {
+		if (size != 10 && size != 30 && size != 50) {
+			size = 10;
+		}
+		return size;
+	}
+
+	private BooleanBuilder parseUUID(String query, ComparableExpressionBase<UUID> uuidField) {
+		try {
+			UUID uuidQuery = UUID.fromString(query);
+			return new BooleanBuilder(uuidField.eq(uuidQuery));
+		} catch (IllegalArgumentException e) {
+			return new BooleanBuilder(); // 잘못된 uuid이면 빈 조건 검색 반환 (검색 무시)
+		}
+	}
+
+	private Sort getSortOrder(String sortBy, String order) {
+
+		if (!isValidSortBy(sortBy)) {
+			throw new IllegalArgumentException("SortBy 는 'createdAt', 'updatedAt', 'deletedAt' 값만 허용합니다.");
+		}
+
+		Sort sort = Sort.by(Sort.Order.by(sortBy));
+
+		sort = getSortDirection(sort, order);
+
+		return sort;
+	}
+
+	private boolean isValidSortBy(String sortBy) {
+
+		return "createdAt".equals(sortBy) || "updatedAt".equals(sortBy) || "deletedAt".equals(sortBy);
+	}
+
+	private Sort getSortDirection(Sort sort, String order) {
+		return "desc".equals(order) ? sort.descending() : sort.ascending();
+	}
+}


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 하나의 JpaRepository에서 queryDSL의 기능까지 같이 구현되어있음
- **to-be**
  - Product JPA Repository에서 QueryDSL 관련 기능을 별도의 인터페이스와 구현체로 분리하여 코드 구조 개선
  - QueryDSL 기능을 담당하는 `ProductQuerydslRepositoryCustom` 인터페이스와 구현체로 리팩터링
  - `JpaProductRepository`는 기존 JPA 기능만 처리하고, QueryDSL 관련 로직은 별도의 클래스에서 처리하도록 변경

## 코멘트

## 관련 이슈
#10



