### PR TITLE
#25 <Order> UPDATE,DELETE 기능 및 queryDSL 리팩터링

### DIFF
--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/application/dto/OrderUpdateReqDto.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/application/dto/OrderUpdateReqDto.java
@@ -1,0 +1,27 @@
+package com.devsquad10.order.application.dto;
+
+import java.util.Date;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderUpdateReqDto {
+
+	private UUID recipientsId;
+
+	private Integer quantity; // 주문 수량
+
+	private String requestDetails; // 요청사항
+
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private Date deadLine; // 납품기한일자
+}

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/application/messaging/OrderMessageService.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/application/messaging/OrderMessageService.java
@@ -1,0 +1,10 @@
+package com.devsquad10.order.application.messaging;
+
+import com.devsquad10.order.application.dto.message.StockDecrementMessage;
+import com.devsquad10.order.application.dto.message.StockReversalMessage;
+
+public interface OrderMessageService {
+	void sendStockDecrementMessage(StockDecrementMessage stockDecrementMessage);
+
+	void sendStockReversalMessage(StockReversalMessage stockReversalMessage);
+}

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/OrderService.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/OrderService.java
@@ -21,6 +21,7 @@ import com.devsquad10.order.application.exception.OrderNotFoundException;
 import com.devsquad10.order.application.messaging.OrderMessageService;
 import com.devsquad10.order.domain.enums.OrderStatus;
 import com.devsquad10.order.domain.model.Order;
+import com.devsquad10.order.domain.repository.OrderQuerydslRepository;
 import com.devsquad10.order.domain.repository.OrderRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class OrderService {
 
 	private final OrderRepository orderRepository;
+	private final OrderQuerydslRepository orderQuerydslRepository;
 	private final OrderMessageService orderMessageService;
 	private final CompanyClient companyClient;
 
@@ -65,7 +67,7 @@ public class OrderService {
 	@Transactional(readOnly = true)
 	public Page<OrderResDto> searchOrders(String q, String category, int page, int size, String sort, String order) {
 
-		Page<Order> orderPages = orderRepository.findAll(q, category, page, size, sort, order);
+		Page<Order> orderPages = orderQuerydslRepository.findAll(q, category, page, size, sort, order);
 
 		return orderPages.map(Order::toResponseDto);
 

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/RabbitMqMessageService.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/RabbitMqMessageService.java
@@ -1,0 +1,33 @@
+package com.devsquad10.order.application.service;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.devsquad10.order.application.dto.message.StockDecrementMessage;
+import com.devsquad10.order.application.dto.message.StockReversalMessage;
+import com.devsquad10.order.application.messaging.OrderMessageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RabbitMqMessageService implements OrderMessageService {
+	private final RabbitTemplate rabbitTemplate;
+
+	@Value("${stockMessage.queue.stock.request}")
+	private String queueRequestStock;
+
+	@Value("${stockMessage.queue.stockRecovery.request}")
+	private String queueStockRecovery;
+	
+	@Override
+	public void sendStockDecrementMessage(StockDecrementMessage stockDecrementMessage) {
+		rabbitTemplate.convertAndSend(queueRequestStock, stockDecrementMessage);
+	}
+
+	@Override
+	public void sendStockReversalMessage(StockReversalMessage stockReversalMessage) {
+		rabbitTemplate.convertAndSend(queueStockRecovery, stockReversalMessage);
+	}
+}

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/domain/model/Order.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/domain/model/Order.java
@@ -20,6 +20,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -52,7 +53,7 @@ public class Order implements Serializable {
 
 	@Column
 	private UUID shippingId; // 배송 ID;
-	
+
 	private String productName; // 상품명
 
 	@Column(nullable = false)
@@ -104,6 +105,12 @@ public class Order implements Serializable {
 		this.createdAt = time;
 		this.updatedAt = time;
 		this.createdBy = "사용자";
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+		this.updatedBy = "사용자";
 	}
 
 	public OrderResDto toResponseDto() {

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/domain/repository/OrderQuerydslRepository.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/domain/repository/OrderQuerydslRepository.java
@@ -1,0 +1,10 @@
+package com.devsquad10.order.domain.repository;
+
+import org.springframework.data.domain.Page;
+
+import com.devsquad10.order.domain.model.Order;
+
+public interface OrderQuerydslRepository {
+
+	Page<Order> findAll(String q, String category, int page, int size, String sort, String order);
+}

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/domain/repository/OrderRepository.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/domain/repository/OrderRepository.java
@@ -3,8 +3,6 @@ package com.devsquad10.order.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-
 import com.devsquad10.order.domain.model.Order;
 
 public interface OrderRepository {
@@ -13,5 +11,4 @@ public interface OrderRepository {
 
 	Order save(Order order);
 
-	Page<Order> findAll(String q, String category, int page, int size, String sort, String order);
 }

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/infrastructure/config/redis/RedisCachingConfig.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/infrastructure/config/redis/RedisCachingConfig.java
@@ -1,0 +1,70 @@
+package com.devsquad10.order.infrastructure.config.redis;
+
+import java.time.Duration;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.devsquad10.order.application.dto.OrderResDto;
+
+@Configuration
+@EnableCaching
+public class RedisCachingConfig {
+
+	public static final String ORDER_CACHE = "orderCache";
+	public static final String ORDER_SEARCH_CACHE = "orderSearchCache";
+
+	private static final Duration DEFAULT_TTL = Duration.ofSeconds(120);
+	private static final Duration ORDER_TTL = Duration.ofMinutes(10);
+	private static final Duration ORDER_SEARCH_TTL = Duration.ofHours(1);
+
+	@Bean
+	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+		// 이진 직렬화 방식 적용
+
+		Jackson2JsonRedisSerializer<OrderResDto> companySerializer = new Jackson2JsonRedisSerializer<>(
+			OrderResDto.class);
+
+		// 기본값 캐시 설정 (2분 TTL, JSON 직렬화 방식)
+		RedisCacheConfiguration defaultConfiguration = RedisCacheConfiguration
+			.defaultCacheConfig()
+			.disableCachingNullValues()
+			.entryTtl(DEFAULT_TTL) // 기본 유지 시간 120초
+			.computePrefixWith(CacheKeyPrefix.simple())
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(companySerializer));
+
+		// companyCache 에 대한 캐시 설정 (10분 TTL, JSON 직렬화 방식)
+		RedisCacheConfiguration companyConfiguration = RedisCacheConfiguration
+			.defaultCacheConfig()
+			.disableCachingNullValues()
+			.entryTtl(ORDER_TTL)
+			.computePrefixWith(CacheKeyPrefix.simple())
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(companySerializer));
+
+		// companySearchCache 에 대한 캐시 설정 (1시간 TTL, JSON 직렬화 방식)
+		RedisCacheConfiguration companySearchConfiguration = RedisCacheConfiguration
+			.defaultCacheConfig()
+			.disableCachingNullValues()
+			.entryTtl(ORDER_SEARCH_TTL)
+			.computePrefixWith(CacheKeyPrefix.simple())
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(companySerializer));
+
+		return RedisCacheManager
+			.builder(redisConnectionFactory)
+			.cacheDefaults(defaultConfiguration)
+			.withCacheConfiguration(ORDER_CACHE, companyConfiguration)
+			.withCacheConfiguration(ORDER_SEARCH_CACHE, companySearchConfiguration)
+			.build();
+	}
+}

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/infrastructure/repository/JpaOrderRepository.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/infrastructure/repository/JpaOrderRepository.java
@@ -2,107 +2,13 @@ package com.devsquad10.order.infrastructure.repository;
 
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import com.devsquad10.order.domain.model.Order;
-import com.devsquad10.order.domain.model.QOrder;
 import com.devsquad10.order.domain.repository.OrderRepository;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.ComparableExpressionBase;
 
 public interface JpaOrderRepository
 	extends JpaRepository<Order, UUID>, QuerydslPredicateExecutor<Order>, OrderRepository {
 
-	default Page<Order> findAll(String query, String category, int page, int size, String sortBy,
-		String order) {
-
-		QOrder qOrder = QOrder.order;
-
-		// 검색 조건 생성
-		BooleanBuilder builder = buildSearchConditions(query, category, qOrder);
-
-		Sort sort = getSortOrder(sortBy, order);
-
-		PageRequest pageRequest = PageRequest.of(page, size, sort);
-
-		return findAll(builder, pageRequest);
-
-	}
-
-	private BooleanBuilder buildSearchConditions(String query, String category, QOrder qOrder) {
-
-		BooleanBuilder builder = new BooleanBuilder();
-
-		builder.and(qOrder.deletedAt.isNull());
-
-		if (query == null || query.isEmpty()) {
-			return builder;
-		}
-
-		if (category == null || category.isEmpty()) {
-			// 카테고리 지정이 없으면 모든 필드에서 검색
-			builder.or(parseUUID(query, qOrder.supplierId));
-			builder.or(parseUUID(query, qOrder.recipientsId));
-			builder.or(parseUUID(query, qOrder.productId));
-			builder.or(parseUUID(query, qOrder.shippingId));
-		} else {
-			switch (category) {
-				case "supplier":
-					builder.or(parseUUID(query, qOrder.supplierId));
-					break;
-				case "recipients":
-					builder.or(parseUUID(query, qOrder.recipientsId));
-					break;
-				case "product":
-					builder.or(parseUUID(query, qOrder.productId));
-					break;
-				case "shipping":
-					builder.or(parseUUID(query, qOrder.shippingId));
-					break;
-				default:
-					builder.or(parseUUID(query, qOrder.supplierId));
-					builder.or(parseUUID(query, qOrder.recipientsId));
-					builder.or(parseUUID(query, qOrder.productId));
-					builder.or(parseUUID(query, qOrder.shippingId));
-					break;
-			}
-		}
-
-		return builder;
-	}
-
-	private BooleanBuilder parseUUID(String query, ComparableExpressionBase<UUID> uuidField) {
-		try {
-			UUID uuidQuery = UUID.fromString(query);
-			return new BooleanBuilder(uuidField.eq(uuidQuery));
-		} catch (IllegalArgumentException e) {
-			return new BooleanBuilder(); // 잘못된 uuid이면 빈 조건 검색 반환 (검색 무시)
-		}
-	}
-
-	private Sort getSortOrder(String sortBy, String order) {
-
-		if (!isValidSortBy(sortBy)) {
-			throw new IllegalArgumentException("SortBy 는 'createdAt', 'updatedAt', 'deletedAt' 값만 허용합니다.");
-		}
-
-		Sort sort = Sort.by(Sort.Order.by(sortBy));
-
-		sort = getSortDirection(sort, order);
-
-		return sort;
-	}
-
-	private boolean isValidSortBy(String sortBy) {
-
-		return "createdAt".equals(sortBy) || "updatedAt".equals(sortBy) || "deletedAt".equals(sortBy);
-	}
-
-	private Sort getSortDirection(Sort sort, String order) {
-		return "desc".equals(order) ? sort.descending() : sort.ascending();
-	}
 }

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/infrastructure/repository/OrderQuerydslRepositoryCustom.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/infrastructure/repository/OrderQuerydslRepositoryCustom.java
@@ -1,0 +1,117 @@
+package com.devsquad10.order.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+import com.devsquad10.order.domain.model.Order;
+import com.devsquad10.order.domain.model.QOrder;
+import com.devsquad10.order.domain.repository.OrderQuerydslRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+
+public interface OrderQuerydslRepositoryCustom
+	extends JpaRepository<Order, UUID>, QuerydslPredicateExecutor<Order>, OrderQuerydslRepository {
+
+	default Page<Order> findAll(String query, String category, int page, int size, String sortBy,
+		String order) {
+
+		size = validateSize(size);
+
+		QOrder qOrder = QOrder.order;
+
+		// 검색 조건 생성
+		BooleanBuilder builder = buildSearchConditions(query, category, qOrder);
+
+		Sort sort = getSortOrder(sortBy, order);
+
+		PageRequest pageRequest = PageRequest.of(page, size, sort);
+
+		return findAll(builder, pageRequest);
+
+	}
+
+	private BooleanBuilder buildSearchConditions(String query, String category, QOrder qOrder) {
+
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(qOrder.deletedAt.isNull());
+
+		if (query == null || query.isEmpty()) {
+			return builder;
+		}
+
+		if (category == null || category.isEmpty()) {
+			// 카테고리 지정이 없으면 모든 필드에서 검색
+			builder.or(parseUUID(query, qOrder.supplierId));
+			builder.or(parseUUID(query, qOrder.recipientsId));
+			builder.or(parseUUID(query, qOrder.productId));
+			builder.or(parseUUID(query, qOrder.shippingId));
+		} else {
+			switch (category) {
+				case "supplier":
+					builder.or(parseUUID(query, qOrder.supplierId));
+					break;
+				case "recipients":
+					builder.or(parseUUID(query, qOrder.recipientsId));
+					break;
+				case "product":
+					builder.or(parseUUID(query, qOrder.productId));
+					break;
+				case "shipping":
+					builder.or(parseUUID(query, qOrder.shippingId));
+					break;
+				default:
+					builder.or(parseUUID(query, qOrder.supplierId));
+					builder.or(parseUUID(query, qOrder.recipientsId));
+					builder.or(parseUUID(query, qOrder.productId));
+					builder.or(parseUUID(query, qOrder.shippingId));
+					break;
+			}
+		}
+
+		return builder;
+	}
+
+	private int validateSize(int size) {
+		if (size != 10 && size != 30 && size != 50) {
+			size = 10;
+		}
+		return size;
+	}
+
+	private BooleanBuilder parseUUID(String query, ComparableExpressionBase<UUID> uuidField) {
+		try {
+			UUID uuidQuery = UUID.fromString(query);
+			return new BooleanBuilder(uuidField.eq(uuidQuery));
+		} catch (IllegalArgumentException e) {
+			return new BooleanBuilder(); // 잘못된 uuid이면 빈 조건 검색 반환 (검색 무시)
+		}
+	}
+
+	private Sort getSortOrder(String sortBy, String order) {
+
+		if (!isValidSortBy(sortBy)) {
+			throw new IllegalArgumentException("SortBy 는 'createdAt', 'updatedAt', 'deletedAt' 값만 허용합니다.");
+		}
+
+		Sort sort = Sort.by(Sort.Order.by(sortBy));
+
+		sort = getSortDirection(sort, order);
+
+		return sort;
+	}
+
+	private boolean isValidSortBy(String sortBy) {
+
+		return "createdAt".equals(sortBy) || "updatedAt".equals(sortBy) || "deletedAt".equals(sortBy);
+	}
+
+	private Sort getSortDirection(Sort sort, String order) {
+		return "desc".equals(order) ? sort.descending() : sort.ascending();
+	}
+}

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devsquad10.order.application.dto.OrderReqDto;
 import com.devsquad10.order.application.dto.OrderResDto;
+import com.devsquad10.order.application.dto.OrderUpdateReqDto;
 import com.devsquad10.order.application.dto.response.OrderResponse;
 import com.devsquad10.order.application.service.OrderService;
 
@@ -54,6 +56,13 @@ public class OrderController {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(OrderResponse.success(HttpStatus.OK.value(),
 				orderService.searchOrders(q, category, page, size, sort, order)));
+	}
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<OrderResponse<OrderResDto>> updateOrder(@PathVariable("id") UUID id,
+		@RequestBody OrderUpdateReqDto orderUpdateReqDto) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(OrderResponse.success(HttpStatus.OK.value(), orderService.updateOrder(id, orderUpdateReqDto)));
 	}
 
 }

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
@@ -32,7 +32,7 @@ public class OrderController {
 
 	@PostMapping
 	public ResponseEntity<OrderResponse<OrderResDto>> createOrder(@RequestBody OrderReqDto orderReqDto) {
-		
+
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(OrderResponse.success(HttpStatus.OK.value(), orderService.createOrder(orderReqDto)));
 	}

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -63,6 +64,13 @@ public class OrderController {
 		@RequestBody OrderUpdateReqDto orderUpdateReqDto) {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(OrderResponse.success(HttpStatus.OK.value(), orderService.updateOrder(id, orderUpdateReqDto)));
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<OrderResponse<String>> deleteOrder(@PathVariable("id") UUID id) {
+		orderService.deleteOrder(id);
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(OrderResponse.success(HttpStatus.OK.value(), "Order Deleted successfully"));
 	}
 
 }

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/presentation/controller/OrderController.java
@@ -31,12 +31,10 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@PostMapping
-	public ResponseEntity<OrderResponse<String>> createOrder(@RequestBody OrderReqDto orderReqDto) {
-
-		orderService.createOrder(orderReqDto);
-
+	public ResponseEntity<OrderResponse<OrderResDto>> createOrder(@RequestBody OrderReqDto orderReqDto) {
+		
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(OrderResponse.success(HttpStatus.OK.value(), "Order received successfully"));
+			.body(OrderResponse.success(HttpStatus.OK.value(), orderService.createOrder(orderReqDto)));
 	}
 
 	@GetMapping("/{id}")

--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/domain/model/Product.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/domain/model/Product.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -93,6 +94,11 @@ public class Product {
 		this.createdAt = time;
 		this.updatedAt = time;
 		this.createdBy = "사용자";
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
 	}
 
 	public ProductResDto toResponseDto() {


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 하나의 JpaRepository에서 queryDSL의 기능까지 같이 구현되어있음
- **to-be**
  - update 기능 추가 ( 재고수량 변경시 product의 재고 증감 및 재고 복원 요청)
  - delete 기능 추가 (논리적 제거된 주문의 수량만큼 재고 복원 요청) 
  - Order JPA Repository에서 QueryDSL 관련 기능을 별도의 인터페이스와 구현체로 분리하여 코드 구조 개선
  - QueryDSL 기능을 담당하는 `OrderQuerydslRepositoryCustom` 인터페이스와 구현체로 리팩터링
  - `JpaOrderRepository`는 기존 JPA 기능만 처리하고, QueryDSL 관련 로직은 별도의 클래스에서 처리하도록 변경

## 코멘트

## 관련 이슈
#25



