### PR TITLE
#101 ShippingCompany 정보 조회 API 추가

### DIFF
--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/application/dto/ShippingCompanyInfoDto.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/application/dto/ShippingCompanyInfoDto.java
@@ -1,0 +1,22 @@
+package com.devsquad10.company.application.dto;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShippingCompanyInfoDto {
+
+	@Column
+	private UUID venderId;
+
+	@Column
+	private UUID hubId;
+}

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
@@ -34,8 +34,9 @@ public class CompanyService {
 	private final HubClient hubClient;
 
 	@CachePut(cacheNames = "companyCache", key = "#result.id")
-	public CompanyResDto createCompany(CompanyReqDto companyReqDto) {
+	public CompanyResDto createCompany(CompanyReqDto companyReqDto, String userId) {
 
+		UUID venderId = UUID.fromString(userId);
 		UUID hubId = companyReqDto.getHubId();
 
 		//1. 허브 존재 유무 확인
@@ -46,6 +47,7 @@ public class CompanyService {
 		// 담당자 id는 유저 완성 시 등록
 		return companyRepository.save(Company.builder()
 			.name(companyReqDto.getName())
+			.venderId(venderId)
 			.hubId(hubId)
 			.address(companyReqDto.getAddress())
 			.type(companyReqDto.getType())

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.devsquad10.company.application.client.HubClient;
 import com.devsquad10.company.application.dto.CompanyReqDto;
 import com.devsquad10.company.application.dto.CompanyResDto;
+import com.devsquad10.company.application.dto.ShippingCompanyInfoDto;
 import com.devsquad10.company.application.exception.CompanyNotFoundException;
 import com.devsquad10.company.domain.enums.CompanyTypes;
 import com.devsquad10.company.domain.model.Company;
@@ -125,5 +126,11 @@ public class CompanyService {
 		Company company = companyRepository.findByIdAndDeletedAtIsNull(id)
 			.orElse(null);
 		return (company != null && company.getType().equals(CompanyTypes.RECIPIENTS)) ? company.getAddress() : null;
+	}
+
+	public ShippingCompanyInfoDto findShippingCompanyInfo(UUID id) {
+		return companyRepository.findByIdAndDeletedAtIsNull(id)
+			.map(company -> new ShippingCompanyInfoDto(company.getVenderId(), company.getHubId()))
+			.orElse(null); // 없을 경우 null 반환
 	}
 }

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/application/service/CompanyService.java
@@ -109,13 +109,19 @@ public class CompanyService {
 			.build());
 	}
 
-	public UUID getHubIdIfCompanyExists(UUID id) {
+	// 상품 등록 시 사용
+	//findSupplierHubIdByCompanyId
+	// getHubIdIfCompanyExists
+	public UUID findSupplierHubIdByCompanyId(UUID id) {
 		Company company = companyRepository.findByIdAndDeletedAtIsNull(id)
 			.orElse(null);
 		return (company != null && company.getType().equals(CompanyTypes.SUPPLIER)) ? company.getHubId() : null;
 	}
 
-	public String getCompanyAddress(UUID id) {
+	// 주문 배송 메시지 생성 시 사용
+	//findRecipientAddressByCompanyId
+	// 원본 명 : getCompanyAddress
+	public String findRecipientAddressByCompanyId(UUID id) {
 		Company company = companyRepository.findByIdAndDeletedAtIsNull(id)
 			.orElse(null);
 		return (company != null && company.getType().equals(CompanyTypes.RECIPIENTS)) ? company.getAddress() : null;

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
@@ -73,12 +73,12 @@ public class CompanyController {
 	}
 
 	@GetMapping("/exists/{uuid}")
-	public UUID getHubIdIfCompanyExists(@PathVariable UUID uuid) {
-		return companyService.getHubIdIfCompanyExists(uuid);  // 존재하면 hubId, 없으면 null
+	public UUID findSupplierHubIdByCompanyId(@PathVariable UUID uuid) {
+		return companyService.findSupplierHubIdByCompanyId(uuid);  // 존재하면 hubId, 없으면 null
 	}
 
 	@GetMapping("/address/{id}")
-	public String getCompanyAddress(@PathVariable UUID id) {
-		return companyService.getCompanyAddress(id);
+	public String findRecipientAddressByCompanyId(@PathVariable UUID id) {
+		return companyService.findRecipientAddressByCompanyId(id);
 	}
 }

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,10 +32,11 @@ public class CompanyController {
 	private final CompanyService companyService;
 
 	@PostMapping
-	public ResponseEntity<CompanyResponse<CompanyResDto>> createCompany(@RequestBody CompanyReqDto companyReqDto) {
+	public ResponseEntity<CompanyResponse<CompanyResDto>> createCompany(
+		@RequestBody CompanyReqDto companyReqDto, @RequestHeader("X-User-Id") String userId) {
 
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(CompanyResponse.success(HttpStatus.OK.value(), companyService.createCompany(companyReqDto)));
+			.body(CompanyResponse.success(HttpStatus.OK.value(), companyService.createCompany(companyReqDto, userId)));
 
 	}
 

--- a/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
+++ b/com.devsquad10.company/src/main/java/com/devsquad10/company/presentation/controller/CompanyController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devsquad10.company.application.dto.CompanyReqDto;
 import com.devsquad10.company.application.dto.CompanyResDto;
+import com.devsquad10.company.application.dto.ShippingCompanyInfoDto;
 import com.devsquad10.company.application.dto.response.CompanyResponse;
 import com.devsquad10.company.application.service.CompanyService;
 
@@ -80,5 +81,10 @@ public class CompanyController {
 	@GetMapping("/address/{id}")
 	public String findRecipientAddressByCompanyId(@PathVariable UUID id) {
 		return companyService.findRecipientAddressByCompanyId(id);
+	}
+
+	@GetMapping("/info/{id}")
+	public ShippingCompanyInfoDto findShippingCompanyInfo(@PathVariable UUID id) {
+		return companyService.findShippingCompanyInfo(id);
 	}
 }

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/application/client/CompanyClient.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/application/client/CompanyClient.java
@@ -10,5 +10,5 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface CompanyClient {
 
 	@GetMapping("/address/{id}")
-	String getCompanyAddress(@PathVariable UUID id);
+	String findRecipientAddressByCompanyId(@PathVariable UUID id);
 }

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/OrderEventService.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/OrderEventService.java
@@ -30,7 +30,7 @@ public class OrderEventService {
 				() -> new OrderNotFoundException("Order Not Found By Id : " + stockDecrementMessage.getOrderId()));
 
 		Optional<String> recipientsAddress = Optional.ofNullable(
-			companyClient.getCompanyAddress(targetOrder.getRecipientsId()));
+			companyClient.findRecipientAddressByCompanyId(targetOrder.getRecipientsId()));
 
 		recipientsAddress.ifPresentOrElse(
 			address -> processValidRecipient(targetOrder, stockDecrementMessage, address),

--- a/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/OrderService.java
+++ b/com.devsquad10.order/src/main/java/com/devsquad10/order/application/service/OrderService.java
@@ -83,7 +83,8 @@ public class OrderService {
 			.orElseThrow(() -> new OrderNotFoundException("Order Not Found By Id : " + id));
 		//1. 배송지 변경 여부 확인
 		if (!order.getRecipientsId().equals(orderUpdateReqDto.getRecipientsId())) {
-			String newRecipientsAddress = companyClient.getCompanyAddress(orderUpdateReqDto.getRecipientsId());
+			String newRecipientsAddress =
+				companyClient.findRecipientAddressByCompanyId(orderUpdateReqDto.getRecipientsId());
 			if (newRecipientsAddress == null) {
 				throw new IllegalArgumentException(
 					"Invalid recipient address for recipientsId: " + orderUpdateReqDto.getRecipientsId());

--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/application/client/CompanyClient.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/application/client/CompanyClient.java
@@ -10,5 +10,5 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface CompanyClient {
 
 	@GetMapping("/exists/{uuid}")
-	UUID getHubIdIfCompanyExists(@PathVariable UUID uuid);
+	UUID findSupplierHubIdByCompanyId(@PathVariable UUID uuid);
 }

--- a/com.devsquad10.product/src/main/java/com/devsquad10/product/application/service/ProductService.java
+++ b/com.devsquad10.product/src/main/java/com/devsquad10/product/application/service/ProductService.java
@@ -37,7 +37,7 @@ public class ProductService {
 
 		// 특정 업체 존재 유무 확인
 		// feign client
-		UUID hubId = companyClient.getHubIdIfCompanyExists(productReqDto.getSupplierId());
+		UUID hubId = companyClient.findSupplierHubIdByCompanyId(productReqDto.getSupplierId());
 
 		if (hubId == null)
 			throw new EntityNotFoundException("Supplier Fot Found By Id : " + productReqDto.getSupplierId());


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**
  - 회사 담당자 ID 및 Hub ID 반환
  - ShippingCompanyInfoDto를 활용하여 응답 데이터 구조화
  - Company 등록 시 헤더의 유저 id 값을 받아 업체 담당자 지정
  - getHubIdIfCompanyExists → findSupplierHubIdByCompanyId
  (공급업체의 Hub ID 조회 메서드로 명확하게 변경)
  - getCompanyAddress → findRecipientAddressByCompanyId
  (수령업체의 주소 조회 메서드로 명확하게 변경)

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

## 관련 이슈
#2 #101