### PR TITLE
#165 Hub 도메인 API 테스트를 통한 Swagger 문서 자동화

### DIFF
--- a/com.devsquad10.gateway/build.gradle
+++ b/com.devsquad10.gateway/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.5.0'
+
     // 분산 추적
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'

--- a/com.devsquad10.gateway/src/main/java/com/devsquad10/gateway/infrastructure/filter/LocalJwtAuthenticationFilter.java
+++ b/com.devsquad10.gateway/src/main/java/com/devsquad10/gateway/infrastructure/filter/LocalJwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class LocalJwtAuthenticationFilter implements GlobalFilter {
 	@Value("${service.jwt.secret-key}")
 	private String secretKey;
 
-	@Value("${spring.profiles.active}")
+	@Value("${spring.profiles.active:default}")
 	private String activeProfile;
 
 	@Override

--- a/com.devsquad10.gateway/src/main/java/com/devsquad10/gateway/infrastructure/filter/LocalJwtAuthenticationFilter.java
+++ b/com.devsquad10.gateway/src/main/java/com/devsquad10/gateway/infrastructure/filter/LocalJwtAuthenticationFilter.java
@@ -30,10 +30,22 @@ public class LocalJwtAuthenticationFilter implements GlobalFilter {
 	@Value("${service.jwt.secret-key}")
 	private String secretKey;
 
+	@Value("${spring.profiles.active}")
+	private String activeProfile;
+
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		String path = exchange.getRequest().getURI().getPath();
 		String method = exchange.getRequest().getMethod().toString();
+
+		// Swagger/API 문서
+		boolean isDocPath = path.startsWith("/springdoc") || path.startsWith("/v3/api-docs") ||
+			path.equals("/docs") || path.contains("swagger-ui");
+
+		// 개발 환경에서만 문서 페이지 접근 가능
+		if (isDocPath && activeProfile.equals("dev")) {
+			return chain.filter(exchange);
+		}
 
 		// 로그인 & 회원가입 API는 토큰 검증 제외
 		if (path.equals("/api/user/signIn") || path.equals("/api/user/signup")) {

--- a/com.devsquad10.hub/build.gradle
+++ b/com.devsquad10.hub/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.9'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 group = 'com.devsquad10'
@@ -28,6 +29,10 @@ ext {
 }
 
 dependencies {
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
+
     // 분산 추적
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
@@ -71,4 +76,56 @@ def querydslSrcDir = 'src/main/generated'
 
 clean {
     delete file(querydslSrcDir)
+}
+
+// 컴파일 시 빌드 폴더 삭제
+compileJava {
+    dependsOn 'clean'
+}
+
+// OpenApi에 들어갈 메타데이터를 추가
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:19092'
+            }
+    ]
+    title = 'HUB API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+// task 생성
+tasks.register('setDocs') {
+    // openapi3 태스크를 먼저 실행
+    dependsOn 'openapi3'
+    // 문서가 다 생성되면 build 파일에 복사
+    // 파일명 뒤에 서비스명을 붙여 중복 생성 방지
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-hub.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-hub.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubController.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubController.java
@@ -23,18 +23,22 @@ import com.devsquad10.hub.application.dto.res.HubGetOneResponseDto;
 import com.devsquad10.hub.application.dto.res.HubUpdateResponseDto;
 import com.devsquad10.hub.application.dto.res.PagedHubResponseDto;
 import com.devsquad10.hub.application.service.HubService;
+import com.devsquad10.hub.presentation.documentation.HubSwaggerDocs;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/hub")
+@Tag(name = "허브 API", description = "허브 위치에 대한 API")
 public class HubController {
 
 	private final HubService hubService;
 
 	@PostMapping
+	@HubSwaggerDocs.CreateHub
 	public ResponseEntity<ApiResponse<HubCreateResponseDto>> createHub(
 		@Valid @RequestBody HubCreateRequestDto request
 	) {
@@ -48,6 +52,7 @@ public class HubController {
 	}
 
 	@GetMapping("/{id}")
+	@HubSwaggerDocs.GetHub
 	public ResponseEntity<ApiResponse<HubGetOneResponseDto>> getHub(
 		@PathVariable UUID id
 	) {
@@ -61,6 +66,7 @@ public class HubController {
 	}
 
 	@PatchMapping("/{id}")
+	@HubSwaggerDocs.UpdateHub
 	public ResponseEntity<ApiResponse<HubUpdateResponseDto>> updateHub(
 		@PathVariable UUID id,
 		@Valid @RequestBody HubUpdateRequestDto request
@@ -75,6 +81,7 @@ public class HubController {
 	}
 
 	@DeleteMapping("/{id}")
+	@HubSwaggerDocs.DeleteHub
 	public ResponseEntity<ApiResponse<String>> deleteHub(
 		@PathVariable UUID id
 	) {
@@ -88,6 +95,7 @@ public class HubController {
 	}
 
 	@GetMapping
+	@HubSwaggerDocs.SearchHubs
 	public ResponseEntity<ApiResponse<PagedHubResponseDto>> getAllHubs(
 		@ModelAttribute @Valid HubSearchRequestDto request
 	) {
@@ -101,11 +109,13 @@ public class HubController {
 	}
 
 	@GetMapping("/exists/{uuid}")
+	@HubSwaggerDocs.ExistsHub
 	public Boolean isHubExists(@PathVariable(name = "uuid") UUID uuid) {
 		return hubService.existById(uuid);
 	}
 
 	@GetMapping("/shipping/{id}")
+	@HubSwaggerDocs.GetHubName
 	public String getHubName(@PathVariable(name = "id") UUID id) {
 		return hubService.getOneHub(id).getName();
 	}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/controller/HubRouteController.java
@@ -25,6 +25,7 @@ import com.devsquad10.hub.application.dto.res.HubRouteUpdateResponseDto;
 import com.devsquad10.hub.application.dto.res.PagedHubRouteResponseDto;
 import com.devsquad10.hub.application.service.HubRouteService;
 import com.devsquad10.hub.infrastructure.client.dto.HubFeignClientGetRequest;
+import com.devsquad10.hub.presentation.documentation.HubRouterSwaggerDocs;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class HubRouteController {
 	private final HubRouteService hubRouteService;
 
 	@PostMapping
+	@HubRouterSwaggerDocs.CreateHubRoute
 	public ResponseEntity<ApiResponse<HubRouteCreateResponseDto>> createHubRoute(
 		@Valid @RequestBody HubRouteCreateRequestDto request
 	) {
@@ -50,6 +52,7 @@ public class HubRouteController {
 	}
 
 	@GetMapping("/{id}")
+	@HubRouterSwaggerDocs.GetHubRoute
 	public ResponseEntity<ApiResponse<HubRouteGetOneResponseDto>> getHubRoute(
 		@PathVariable UUID id
 	) {
@@ -63,6 +66,7 @@ public class HubRouteController {
 	}
 
 	@PatchMapping("/{id}")
+	@HubRouterSwaggerDocs.UpdateHubRoute
 	public ResponseEntity<ApiResponse<HubRouteUpdateResponseDto>> updateHubRoute(
 		@PathVariable UUID id,
 		@Valid @RequestBody HubRouteUpdateRequestDto request
@@ -77,6 +81,7 @@ public class HubRouteController {
 	}
 
 	@DeleteMapping("/{id}")
+	@HubRouterSwaggerDocs.DeleteHubRoute
 	public ResponseEntity<ApiResponse<String>> deleteHubRoute(
 		@PathVariable UUID id
 	) {
@@ -89,6 +94,7 @@ public class HubRouteController {
 	}
 
 	@GetMapping
+	@HubRouterSwaggerDocs.SearchHubRoutes
 	public ResponseEntity<ApiResponse<PagedHubRouteResponseDto>> getAllHubs(
 		@ModelAttribute @Valid HubRouteSearchRequestDto request
 	) {
@@ -102,6 +108,7 @@ public class HubRouteController {
 	}
 
 	@GetMapping("/info/{departureHubId}/{destinationHubId}")
+	@HubRouterSwaggerDocs.getHubRouteInfo
 	public List<HubFeignClientGetRequest> getHubRouteInfo(
 		@PathVariable("departureHubId") UUID departureHubId,
 		@PathVariable("destinationHubId") UUID destinationHubId

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/documentation/HubRouterSwaggerDocs.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/documentation/HubRouterSwaggerDocs.java
@@ -1,0 +1,120 @@
+package com.devsquad10.hub.presentation.documentation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.devsquad10.hub.infrastructure.client.dto.HubFeignClientGetRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface HubRouterSwaggerDocs {
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 경로 생성", description = "두 허브 간의 이동 경로를 생성합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 경로 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "유효성 검증 실패 또는 존재하지 않는 허브"),
+		@ApiResponse(responseCode = "403", description = "허브 경로 생성 권한 없음 (마스터 관리자만 가능)"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface CreateHubRoute {}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 경로 조회", description = "특정 허브 경로의 상세 정보를 조회합니다.")
+	@Parameters({
+		@Parameter(name = "id", description = "조회할 허브 경로 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 경로 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "허브 경로를 찾을 수 없음"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface GetHubRoute {}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 경로 검색", description = "검색 조건에 맞는 허브 경로 목록을 페이징하여 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 경로 검색 성공"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface SearchHubRoutes {}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 경로 수정", description = "허브 간 이동 경로 정보를 수정합니다.")
+	@Parameters({
+		@Parameter(name = "id", description = "수정할 허브 경로 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 경로 수정 성공"),
+		@ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+		@ApiResponse(responseCode = "403", description = "허브 경로 수정 권한 없음 (마스터 관리자만 가능)"),
+		@ApiResponse(responseCode = "404", description = "허브 경로를 찾을 수 없음"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface UpdateHubRoute {}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 경로 삭제", description = "허브 간 이동 경로를 논리적으로 삭제합니다.")
+	@Parameters({
+		@Parameter(name = "id", description = "삭제할 허브 경로 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 경로 삭제 성공"),
+		@ApiResponse(responseCode = "403", description = "허브 경로 삭제 권한 없음 (마스터 관리자만 가능)"),
+		@ApiResponse(responseCode = "404", description = "허브 경로를 찾을 수 없음"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface DeleteHubRoute {}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(
+		summary = "허브 경로 정보 조회 (내부 API)",
+		description = "출발 허브와 도착 허브 간의 경로 정보를 조회합니다. 서비스 간 내부 통신용 API입니다."
+	)
+	@Parameters({
+		@Parameter(
+			name = "departureHubId",
+			description = "출발 허브 ID",
+			required = true,
+			example = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+		),
+		@Parameter(
+			name = "destinationHubId",
+			description = "도착 허브 ID",
+			required = true,
+			example = "e37bc10b-48cc-4372-b567-0e02b2c3d123"
+		)
+	})
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "허브 경로 정보 조회 성공",
+			content = @Content(
+				mediaType = "application/json",
+				array = @ArraySchema(schema = @Schema(implementation = HubFeignClientGetRequest.class))
+			)
+		),
+		@ApiResponse(responseCode = "404", description = "출발지 또는 도착지 허브를 찾을 수 없음"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface getHubRouteInfo {}
+}

--- a/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/documentation/HubSwaggerDocs.java
+++ b/com.devsquad10.hub/src/main/java/com/devsquad10/hub/presentation/documentation/HubSwaggerDocs.java
@@ -1,0 +1,121 @@
+package com.devsquad10.hub.presentation.documentation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface HubSwaggerDocs {
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 생성", description = "새로운 물류 허브를 생성합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+		@ApiResponse(responseCode = "403", description = "허브 생성 권한 없음 (마스터 관리자만 가능)"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface CreateHub {
+	}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 조회", description = "특정 허브의 상세 정보를 조회합니다.")
+	@Parameters({
+		@Parameter(name = "id", description = "조회할 허브 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "허브를 찾을 수 없음"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface GetHub {
+	}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 목록 조회", description = "검색 조건에 맞는 허브 목록을 페이징하여 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 목록 조회 성공"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface SearchHubs {
+	}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 수정", description = "특정 허브의 정보를 수정합니다.")
+	@Parameters({
+		@Parameter(name = "id", description = "수정할 허브 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 수정 성공"),
+		@ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+		@ApiResponse(responseCode = "403", description = "허브 수정 권한 없음 (마스터 관리자만 가능)"),
+		@ApiResponse(responseCode = "404", description = "허브를 찾을 수 없음"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface UpdateHub {
+	}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 삭제", description = "특정 허브를 논리적으로 삭제합니다.")
+	@Parameters({
+		@Parameter(name = "id", description = "삭제할 허브 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "허브 삭제 성공"),
+		@ApiResponse(responseCode = "403", description = "허브 삭제 권한 없음 (마스터 관리자만 가능)"),
+		@ApiResponse(responseCode = "404", description = "허브를 찾을 수 없음"),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	@interface DeleteHub {
+	}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(summary = "허브 존재 확인", description = "특정 허브 ID가 존재하는지 확인합니다. FeignClient용 API입니다.")
+	@Parameters({
+		@Parameter(name = "uuid", description = "존재 여부를 확인할 허브 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "확인 성공", content = @Content(schema = @Schema(implementation = Boolean.class)))
+	})
+	@interface ExistsHub {
+	}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Operation(
+		summary = "허브 이름 조회 (내부 API)",
+		description = "특정 허브 ID의 이름을 조회합니다. 서비스 간 내부 통신용 API입니다."
+	)
+	@Parameters({
+		@Parameter(name = "id", description = "조회할 허브 ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	})
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "허브 이름 조회 성공",
+			content = @Content(schema = @Schema(type = "string"), examples = @ExampleObject(value = "서울특별시 센터"))
+		),
+		@ApiResponse(responseCode = "404", description = "허브를 찾을 수 없음")
+	})
+	@interface GetHubName {
+	}
+}

--- a/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubApiDocsTest.java
+++ b/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubApiDocsTest.java
@@ -1,0 +1,90 @@
+package com.devsquad10.hub;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.devsquad10.hub.application.dto.req.HubCreateRequestDto;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+public class HubApiDocsTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	void testHubPostSuccessWithDocs() throws Exception {
+
+		HubCreateRequestDto requestDto = HubCreateRequestDto.builder()
+			.name("테스트 센터")
+			.address("경기도 성남시 분당구 정자일로 95")
+			.latitude(37.3591784)
+			.longitude(127.1048319)
+			.build();
+
+		String requestJson = objectMapper.writeValueAsString(requestDto);
+
+		mockMvc.perform(
+				RestDocumentationRequestBuilders.post("/api/hub")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(requestJson)
+					.header("Authorization", "Bearer test-token")
+			)
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andDo(
+				MockMvcRestDocumentationWrapper.document("hub-create-success",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					resource(ResourceSnippetParameters.builder()
+						.tag("Hub API")
+						.description("허브 생성 API")
+						.requestFields(
+							fieldWithPath("name").description("허브 이름"),
+							fieldWithPath("address").description("허브 주소"),
+							fieldWithPath("latitude").description("위도"),
+							fieldWithPath("longitude").description("경도")
+						)
+						.responseFields(
+							fieldWithPath("status").description("HTTP 상태 코드"),
+							fieldWithPath("success").description("성공 여부"),
+							fieldWithPath("body.id").description("생성된 허브 ID"),
+							fieldWithPath("body.name").description("허브 이름"),
+							fieldWithPath("body.address").description("허브 주소"),
+							fieldWithPath("body.latitude").description("위도"),
+							fieldWithPath("body.longitude").description("경도"),
+							fieldWithPath("body.createdAt").description("생성 시간"),
+							fieldWithPath("body.createdBy").description("생성자 ID"),
+							fieldWithPath("body.updatedAt").description("마지막 수정 시간"),
+							fieldWithPath("body.updatedBy").description("수정자 ID"),
+							fieldWithPath("body.deletedAt").description("삭제 시간(null이면 삭제되지 않음)").optional(),
+							fieldWithPath("body.deletedBy").description("삭제자 ID(null이면 삭제되지 않음)").optional()
+						)
+						.build()
+					)
+				)
+			);
+	}
+}

--- a/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubApiDocsTest.java
+++ b/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubApiDocsTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import com.devsquad10.hub.application.dto.req.HubCreateRequestDto;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.transaction.Transactional;
@@ -61,6 +62,8 @@ public class HubApiDocsTest {
 					resource(ResourceSnippetParameters.builder()
 						.tag("Hub API")
 						.description("허브 생성 API")
+						.requestSchema(Schema.schema("HubCreateRequestDto"))
+						.responseSchema(Schema.schema("HubCreateResponseDto"))
 						.requestFields(
 							fieldWithPath("name").description("허브 이름"),
 							fieldWithPath("address").description("허브 주소"),

--- a/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubIntegrationTest.java
+++ b/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubIntegrationTest.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
@@ -28,6 +30,8 @@ import com.devsquad10.hub.domain.repository.HubRepository;
 import jakarta.transaction.Transactional;
 
 @SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")
 public class HubIntegrationTest {

--- a/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubRouteIntegrationTest.java
+++ b/com.devsquad10.hub/src/test/java/com/devsquad10/hub/HubRouteIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Sort;
@@ -36,6 +37,7 @@ import com.devsquad10.hub.infrastructure.client.dto.NaverDirections5Response;
 import jakarta.transaction.Transactional;
 
 @SpringBootTest
+@AutoConfigureRestDocs
 @Transactional
 @ActiveProfiles("test")
 public class HubRouteIntegrationTest {


### PR DESCRIPTION
## 변경 타입
- [X] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**
  - 커스텀 어노테이션을 통한 swagger code 간소화
  - swagger+restdoc 혼합 방식을 통한 test 코드 작성시 swagger 문서 생성
  - gateway의 /docs 경로에서 생성한 doc 확인 (dev환경에서만)

## 코멘트
- Gateway 코드를 수정하였습니다. **gateway yml파일 변경이 필요합니다.**

## 관련 이슈
Closes: #165